### PR TITLE
varnish-enterprise: Bump minor version and add to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         chart:
           - varnish-cache
           - orca-chart
+          - varnish-enterprise
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/varnish-enterprise/Chart.yaml
+++ b/varnish-enterprise/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: varnish-enterprise
 description: Varnish Enterprise Helm chart
 type: application
-version: 1.7.0
+version: 1.7.1
 appVersion: 6.0.16r4
 maintainers:
   - email: containers@varnish-software.com


### PR DESCRIPTION
Push varnish enterprise chart to docker and packagecloud