### PR TITLE
fix: identation error on orca deployment template

### DIFF
--- a/orca-chart/templates/deployment.yaml
+++ b/orca-chart/templates/deployment.yaml
@@ -84,7 +84,7 @@ spec:
             {{- end -}}
           {{- end -}}
           {{- with .Values.volumeMounts }}
-            {{- toYaml . | nindent 12 }}
+            {{- toYaml . | nindent 10 }}
           {{- end }}
       volumes:
       - name: orca-config
@@ -117,7 +117,7 @@ spec:
         {{- end -}}
       {{- end -}}
       {{- with .Values.volumes }}
-        {{- toYaml . | nindent 8 }}
+        {{- toYaml . | nindent 6 }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
Hey, 

I noticed when using orca-helm chart that the identation is not correct when trying to use the "volumeMounts" or "volumes" section. I created an fix for that. 

Values to replicate that: 

```yaml
replicaCount: 2
image:
  repository: test.io/docker/varnish/orca
  tag: 0.6.2
imagePullSecrets:
  - name: docker-auth-config
orca:
  license:
    secret: orca-license
  otel:
    service_name: orca
    metrics:
      enabled: true
      endpoint: http://test:4317
      protocol: grpc
  varnish:
    http:
      - port: 80
    https:
      - port: 443
        certificates:
          - secret: orca-tls
  virtual_registry:
    registries:
      - name: jfrog
        default: true
        remotes:
          - url: https://test.io
volumeMounts:
  - name: cache-storage
    mountPath: /var/lib/varnish
volumes:
  - name: cache-storage
    persistentVolumeClaim:
      claimName: orca-cache-storage
```

If you have any questions, let me know!