### PR TITLE
Extraenvs

### DIFF
--- a/orca-chart/README.md
+++ b/orca-chart/README.md
@@ -48,6 +48,7 @@ orca:
 | `autoscaling.maxReplicas` | int | `100` |  |
 | `autoscaling.minReplicas` | int | `1` |  |
 | `autoscaling.targetCPUUtilizationPercentage` | int | `80` |  |
+| `extraEnvs` | object | `{}` | Set extra environment variables |
 | `fullnameOverride` | string | `""` |  |
 | `image.pullPolicy` | string | `"IfNotPresent"` |  |
 | `image.repository` | string | `"docker.io/varnish/orca"` | |

--- a/orca-chart/templates/_helpers.tpl
+++ b/orca-chart/templates/_helpers.tpl
@@ -81,3 +81,20 @@ It also supports storing TLS certificates in secrets before mounting them into t
   {{- end -}}
   {{- toYaml $cfg -}}
 {{- end -}}
+
+{{/*
+Sets extra envs from either an array, an object, or a string.
+*/}}
+{{- define "orca.toEnv" }}
+{{- $tp := kindOf .envs }}
+{{- if eq $tp "string" }}
+{{- tpl .envs . | trim | nindent 0 }}
+{{- else if eq $tp "map" }}
+{{- range $k, $v := .envs -}}
+- name: {{ $k | quote }}
+  value: {{ $v | quote }}
+{{- end }}
+{{- else if eq $tp "slice" }}
+{{- .envs | toYaml }}
+{{- end }}
+{{- end }}

--- a/orca-chart/templates/deployment.yaml
+++ b/orca-chart/templates/deployment.yaml
@@ -56,6 +56,10 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if and .Values.extraEnvs (not (empty .Values.extraEnvs)) }}
+          env:
+            {{- include "orca.toEnv" (merge (dict "envs" .Values.extraEnvs) .) | nindent 12 }}
+          {{- end }}
           volumeMounts:
           - name: orca-config
             mountPath: /etc/varnish-supervisor/config.yaml

--- a/orca-chart/values.yaml
+++ b/orca-chart/values.yaml
@@ -105,7 +105,7 @@ volumeMounts: []
 #   mountPath: "/etc/foo"
 #   readOnly: true
 
-# Sets the extra environment variables for Varnish Cache. Can be set as either
+# Sets the extra environment variables for Varnish Orca. Can be set as either
 # an object, a list, or a templated string.
 extraEnvs: {}
 #extraEnvs:

--- a/orca-chart/values.yaml
+++ b/orca-chart/values.yaml
@@ -105,6 +105,23 @@ volumeMounts: []
 #   mountPath: "/etc/foo"
 #   readOnly: true
 
+# Sets the extra environment variables for Varnish Cache. Can be set as either
+# an object, a list, or a templated string.
+extraEnvs: {}
+#extraEnvs:
+#  MY_ENV_VAR: value
+#  MY_OTHER_ENV_VAR: other_value
+#
+#extraEnvs:
+#  - name: MY_ENV_VAR
+#    value: value
+#  - name: MY_OTHER_ENV_VAR
+#    valueFrom:
+#      configMapRef:
+#        name: my-config-map
+#        value: my-key
+#
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
Add support for `extraEnvs` to ensure the git authentication token can be set for the Artifact Firewall