### PR TITLE
Repository dispatch endpoint for version bumper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,15 @@ jobs:
           helm package "${{ matrix.chart }}"
           mkdir -p /tmp/artifacts
           cp "${{ matrix.chart }}"-*.tgz /tmp/artifacts
+      - name: "Check version does not already exist"
+        if: ${{ github.event.inputs.publish == matrix.chart }}
+        run: |
+          VERSION=$(yq -r '.version' "${{ matrix.chart }}/Chart.yaml")
+          echo ${{ secrets.DOCKERHUB_TOKEN }} | helm registry login -u "varnish" --password-stdin registry-1.docker.io
+          if helm pull "oci://registry-1.docker.io/varnish/${{ matrix.chart }}" --version "$VERSION" --destination /tmp 2>/dev/null; then
+            echo "Error: ${{ matrix.chart }} version $VERSION already exists in the registry"
+            exit 1
+          fi
       - name: "Push chart"
         if: ${{ github.event.inputs.publish == matrix.chart }}
         run: |

--- a/.github/workflows/version_bumper.yaml
+++ b/.github/workflows/version_bumper.yaml
@@ -10,6 +10,9 @@ on:
   schedule:
     - cron: '0 0 * * 0'
   workflow_dispatch:
+  repository_dispatch:
+    types:
+      - bump_version
 
 jobs:
   version_bump:


### PR DESCRIPTION
This PR adds a `repository_dispatch` endpoint to the version bumper workflow. This makes it possible to have other repositories dispatch a `bump_version` event on release, and have an automatic PR created in this repo without having to either trigger it manually or wait for the next full moon.

You still have to approve and merge the version bump PR manually, no change there. 

I also added an extra safety check to the build and push workflow.