### PR TITLE
Unify varnish enterprise and varnish-cache helmchart

### DIFF
--- a/varnish-enterprise/templates/_pod.tpl
+++ b/varnish-enterprise/templates/_pod.tpl
@@ -342,11 +342,22 @@ Composing the $varnishArgs list or arguments
     {{- $varnishArgs = concat $varnishArgs (list "-S" "/etc/varnish/secret" ) }}
 {{- end -}}
 {{/*
-    MSE
+    Stevedores
 */}}
-{{- if and (and (eq (kindOf .Values.server.mse.enabled) "bool") .Values.server.mse.enabled) .Values.server.mse4.enabled }}
-  {{- fail "Only one of MSE or MSE4 can be enabled at the same time: 'server.mse.enabled' or 'server.mse4.enabled'" }}
-{{- else if or (and (eq (kindOf .Values.server.mse.enabled) "bool") .Values.server.mse.enabled) (and (eq (kindOf .Values.server.mse.enabled) "string") (eq .Values.server.mse.enabled "-") (not .Values.server.mse4.enabled)) }}
+{{- $mse := false }}
+{{- $mse4 := .Values.server.mse4.enabled }}
+{{- $malloc := .Values.server.malloc.enabled }}
+{{- if or (and (eq (kindOf .Values.server.mse.enabled) "string") (eq .Values.server.mse.enabled "-") (not $mse4) (not $malloc) ) (and (eq (kindOf .Values.server.mse.enabled) "bool") .Values.server.mse.enabled) }}
+  {{- $mse = true }}
+{{- else }}
+  {{- $mse = false }}
+{{- end }}
+
+{{- if or (and $malloc $mse) (and $malloc $mse4) (and $mse $mse4) }}
+  {{- fail "Only one of these storages can be enabled at the same time: 'server.mse.enabled', 'server.mse4.enabled', 'server.malloc.enabled'" }}
+{{- end }}
+
+{{- if $mse }}
   {{- if and .Values.server.mse.memoryTarget (not (eq .Values.server.mse.memoryTarget "")) }}
     {{- $varnishArgs = concat $varnishArgs (list "-p" (print "memory_target=" (toString .Values.server.mse.memoryTarget)))}}
   {{- end }}
@@ -355,7 +366,7 @@ Composing the $varnishArgs list or arguments
   {{- else }}
     {{- $varnishArgs = concat $varnishArgs (list "-s" "mse") }}
   {{- end }}
-{{- else if .Values.server.mse4.enabled }}
+{{- else if $mse4 }}
   {{- if and .Values.server.mse4.memoryTarget (not (eq .Values.server.mse4.memoryTarget "")) }}
     {{- $varnishArgs = concat $varnishArgs (list "-p" (print "memory_target=" (toString .Values.server.mse4.memoryTarget))) }}
   {{- end }}
@@ -364,8 +375,17 @@ Composing the $varnishArgs list or arguments
   {{- else }}
     {{- $varnishArgs = concat $varnishArgs (list "-s" "mse4") }}
   {{- end }}
+{{- else if $malloc }}
+  {{- if (eq (kindOf .Values.server.malloc.size) ("string")) }}
+    {{- $varnishArgs = concat $varnishArgs (list "-s" (printf "malloc,%s" .Values.server.malloc.size ) ) }}
+  {{- else }}
+    {{- $varnishArgs = concat $varnishArgs (list "-s" "malloc") }}
+  {{- end -}}
+  {{- if (eq (kindOf .Values.server.malloc.transient.size) ("string")) }}
+    {{- $varnishArgs = concat $varnishArgs (list "-s" (printf "Transient=malloc,%s" .Values.server.malloc.transient.size)) }}
+  {{- end }}
 {{- else }}
-{{- fail "Either MSE or MSE4 must be enabled: 'server.mse.enabled' or 'server.mse4.enabled'" }}
+  {{- fail "Exactly one of MSE, MSE4 or malloc must be enabled: 'server.mse.enabled', 'server.mse4.enabled', 'server.malloc.enabled'" }}
 {{- end -}}
 {{/*
     TLS
@@ -488,7 +508,6 @@ Composing the $varnishArgs list or arguments
       value: "mse4"
     {{- end }}
     {{- else }}
-    {{- fail "Either MSE or MSE4 must be enabled: 'server.mse.enabled' or 'server.mse4.enabled'" }}
     {{- end }}
 
     {{- if .Values.server.tls.enabled }}

--- a/varnish-enterprise/test/unit_common/common.bats
+++ b/varnish-enterprise/test/unit_common/common.bats
@@ -2918,7 +2918,7 @@ env: {
         . || echo "---") 2>&1 |
         tee -a /dev/stderr)
 
-    [[ "${actual}" == *"Either MSE or MSE4 must be enabled: 'server.mse.enabled' or 'server.mse4.enabled'"* ]]
+    [[ "${actual}" == *"Exactly one of MSE, MSE4 or malloc must be enabled:"* ]]
 }
 
 @test "${kind}/mse/config: can be disabled when mse4 is enabled" {
@@ -2974,7 +2974,7 @@ env: {
         . || echo "---") 2>&1 |
         tee -a /dev/stderr)
 
-    [[ "${actual}" == *"Only one of MSE or MSE4 can be enabled at the same time: 'server.mse.enabled' or 'server.mse4.enabled'"* ]]
+    [[ "${actual}" == *"Only one of these storages can be enabled at the same time:"* ]]
 }
 
 @test "${kind}/mse4/memoryTarget: can be configured" {
@@ -3120,6 +3120,59 @@ env: {
             tee -a /dev/stderr)
     [ "${actual}" == '' ]
 }
+
+@test "${kind}/malloc/config: not configured by default" {
+    cd "$(chart_dir)"
+
+    local object=$((helm template \
+        --set "server.kind=${kind}" \
+        --set 'server.malloc.enabled=true' \
+        --namespace default \
+        --show-only ${template} \
+        . || echo "---") |
+        tee -a /dev/stderr)
+
+    local container=$(echo "$object" |
+        yq -r -c '
+            .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
+            tee -a /dev/stderr)
+
+    local actual=$(echo "$container" |
+        yq -r -c '.command | .[ index("-s") + 1 ] | split(",")[1]' |
+            tee -a /dev/stderr)
+    [ "${actual}" == "null" ]
+}
+
+@test "${kind}/malloc/config: can be configured" {
+    cd "$(chart_dir)"
+
+    local object=$((helm template \
+        --set "server.kind=${kind}" \
+        --set 'server.malloc.enabled=true' \
+        --set 'server.malloc.size=2G' \
+        --set 'server.malloc.transient.size=1G' \
+        --namespace default \
+        --show-only ${template} \
+        . || echo "---") |
+        tee -a /dev/stderr)
+
+    local container=$(echo "$object" |
+        yq -r -c '
+            .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
+            tee -a /dev/stderr)
+
+    local actual=$(echo "$container" |
+        yq -r -c '.command | .[ indices("-s")[0]+1 ] | split(",")[1]' |
+            tee -a /dev/stderr)
+    [ "${actual}" == "2G" ]
+
+    local actual=$(echo "$container" |
+        yq -r -c '.command |  .[ indices("-s")[1]+1]' |
+            tee -a /dev/stderr)
+    [ "${actual}" == "Transient=malloc,1G" ]
+
+}
+
 
 @test "${kind}/delayedHaltSeconds: not enabled by default" {
     cd "$(chart_dir)"

--- a/varnish-enterprise/values.yaml
+++ b/varnish-enterprise/values.yaml
@@ -438,9 +438,9 @@ server:
   mse:
     # Enables Massive Storage Engine. Only one of `server.mse.enabled` or `server.mse4.enabled` must be enabled.
     #
-    # When set to a string "-", `server.mse.enabled` will be set to an opposite value of `server.mse4.enabled` (i.e. automatically disabling MSE when MSE4 is enabled, and vice versa)
+    # When set to a string "-", or null, `server.mse.enabled` will be set to an opposite value of `server.mse4.enabled` (i.e. automatically disabling MSE when MSE4 is enabled, and vice versa)
     # Availability: v1.6.1
-    # Type: boolean or string
+    # Type: boolean, string or null
     enabled: "-"
 
     # Sets the amount of memory to use for MSE. The value can be set as either a percentage (e.g., "80%"),
@@ -604,6 +604,15 @@ server:
 
       # Sets the storage size for Persistence Volume Claim for MSE4.
       storageSize: "10Gi"
+
+  malloc:
+    # Enables malloc storage, the default storage engine for open-source varnish:
+    enabled: false
+    # Sets the size of the malloc. Default is unbounded.
+    size: ~
+    transient:
+      # Sets the size of the transient buffer. Default is unbounded.
+      size: ~
 
   # Sets the Varnish secret for accessing the varnishd admin interface. Either this value or
   # `server.secretFrom` can be set.


### PR DESCRIPTION
This is just adding `malloc` as a stevedore to the enterprise helm chart, which is the first step to get it running with opensource varnish.