### PR TITLE
Edition gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ on:
           - varnish-enterprise
           - varnish-controller
           - varnish-controller-router
+      varnish_cache_version:
+        description: "Varnish Cache OSS version to publish (required when publishing varnish-cache, e.g. 9.0.3)"
+        type: string
+        required: false
 
 jobs:
   build_and_push:
@@ -36,10 +40,24 @@ jobs:
 
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends bats parallel
+      - name: "Generate community chart"
+        if: matrix.chart == 'varnish-cache'
+        run: |
+          if [ "${{ github.event.inputs.publish }}" = "varnish-cache" ]; then
+            if [ -z "${{ github.event.inputs.varnish_cache_version }}" ]; then
+              echo "Error: varnish_cache_version input is required when publishing varnish-cache"
+              exit 1
+            fi
+            VERSION="${{ github.event.inputs.varnish_cache_version }}"
+          else
+            VERSION="latest"
+          fi
+          bash ci/publish-community.sh "$VERSION" dist/varnish-cache
       - name: "Add Helm dependencies"
         # See also: https://circleci.com/docs/env-vars/#alpine-linux
         run: |
-            cd ${{ matrix.chart }}
+            CHART_DIR=${{ matrix.chart == 'varnish-cache' && 'dist/varnish-cache' || matrix.chart }}
+            cd "$CHART_DIR"
             # Helm is painful https://github.com/helm/helm/issues/8036
             i=0
             yq -r '.dependencies[]?.repository' < Chart.yaml | while read -r p; do
@@ -57,13 +75,15 @@ jobs:
           fi
       - name: Create package
         run: |
-          helm package "${{ matrix.chart }}"
+          CHART_DIR=${{ matrix.chart == 'varnish-cache' && 'dist/varnish-cache' || matrix.chart }}
+          helm package "$CHART_DIR"
           mkdir -p /tmp/artifacts
           cp "${{ matrix.chart }}"-*.tgz /tmp/artifacts
       - name: "Check version does not already exist"
         if: ${{ github.event.inputs.publish == matrix.chart }}
         run: |
-          VERSION=$(yq -r '.version' "${{ matrix.chart }}/Chart.yaml")
+          CHART_DIR=${{ matrix.chart == 'varnish-cache' && 'dist/varnish-cache' || matrix.chart }}
+          VERSION=$(yq -r '.version' "$CHART_DIR/Chart.yaml")
           echo ${{ secrets.DOCKERHUB_TOKEN }} | helm registry login -u "varnish" --password-stdin registry-1.docker.io
           if helm pull "oci://registry-1.docker.io/varnish/${{ matrix.chart }}" --version "$VERSION" --destination /tmp 2>/dev/null; then
             echo "Error: ${{ matrix.chart }} version $VERSION already exists in the registry"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,6 @@ jobs:
           tar xavf /tmp/helm.tar.gz
           mv linux-amd64/helm /usr/local/bin/helm
 
-          pip install yq
-
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends bats parallel
       - name: "Add Helm dependencies"
@@ -51,10 +49,10 @@ jobs:
             helm dependency build
       - name: "Unit tests"
         run: |
-          if [ -x ${{ matrix.chart }}/test/unit/run.sh ]; then 
+          if [ -x ${{ matrix.chart }}/test/unit/run.sh ]; then
             ${{ matrix.chart }}/test/unit/run.sh -j 50
           fi
-          if [ -x ${{ matrix.chart }}/test/unit_common/run.sh ]; then 
+          if [ -x ${{ matrix.chart }}/test/unit_common/run.sh ]; then
             ${{ matrix.chart }}/test/unit_common/run.sh -j 50
           fi
       - name: Create package

--- a/README.md
+++ b/README.md
@@ -2,11 +2,38 @@
 
 This repository hosts Helm charts for Varnish Cache and related projects.
 
-## Documentation
+## Charts
 
-For documentation, please see README.md in each chart's directory.
+### Varnish Enterprise
 
-- [varnish-cache](varnish-cache/README.md)
+The `varnish-enterprise/` chart is the **single source of truth** for both the enterprise and community charts. It targets the Varnish Enterprise image from `quay.io/varnish-software/varnish-plus` by default.
+
+For full documentation see the [Varnish Enterprise Helm Chart docs](https://docs.varnish-software.com/varnish-helm/varnish-enterprise/).
+
+### Varnish Cache (Community)
+
+The community chart is **generated** from the enterprise chart at publish time. It is not maintained separately. Do not edit the `varnish-cache/` directory by hand.
+
+To build the community chart:
+
+```sh
+./ci/publish-community.sh <oss-version> [output-dir]
+```
+
+- `oss-version`: the Varnish Cache OSS release to target, e.g. `9.0.3`. This sets the `appVersion` in `Chart.yaml` and the default image tag (`docker.io/varnish:<oss-version>`).
+- `output-dir`: where to write the generated chart. Defaults to `./dist/varnish-cache`.
+
+Example:
+
+```sh
+./ci/publish-community.sh 9.0.3
+helm package dist/varnish-cache --destination dist/packages
+```
+
+The script requires `yq` (kislyuk/yq) and `helm`.
+
+### Other Charts
+
 - [orca-chart](orca-chart/README.md)
 
 ## Enterprise Customers

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Example:
 helm package dist/varnish-cache --destination dist/packages
 ```
 
-The script requires `yq` (kislyuk/yq) and `helm`.
+The script requires [`yq`](https://github.com/mikefarah/yq) (go-yq) and `helm`.
 
 ### Other Charts
 

--- a/ci/publish-community.sh
+++ b/ci/publish-community.sh
@@ -23,7 +23,7 @@ if [ -z "$1" ]; then
 fi
 
 OSS_VERSION="$1"
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_ROOT="$(realpath "$(dirname "$0")/..")"
 SRC="$REPO_ROOT/varnish-enterprise"
 OUT="${2:-$REPO_ROOT/dist/varnish-cache}"
 

--- a/ci/publish-community.sh
+++ b/ci/publish-community.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+# Builds the varnish-cache community chart from the varnish-enterprise source.
+#
+# The enterprise chart is the single source of truth. This script transforms it
+# into the community chart by switching the edition, changing the default image,
+# and stripping enterprise-only values so they never appear in the published chart.
+#
+# Usage:
+#   ./ci/publish-community.sh <oss-version> [output-dir]
+#
+# oss-version: the Varnish Cache release to target, e.g. "9.0.3"
+#              This sets Chart.yaml appVersion and the default image tag.
+# output-dir:  defaults to ./dist/varnish-cache
+#
+# Requires yq (kislyuk/yq) and helm.
+
+set -e
+
+if [ -z "$1" ]; then
+    echo "Usage: $0 <oss-version> [output-dir]" >&2
+    echo "  e.g. $0 9.0.3" >&2
+    exit 1
+fi
+
+OSS_VERSION="$1"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SRC="$REPO_ROOT/varnish-enterprise"
+OUT="${2:-$REPO_ROOT/dist/varnish-cache}"
+
+if ! command -v yq > /dev/null 2>&1; then
+    echo "Error: yq is required (https://github.com/mikefarah/yq)" >&2
+    exit 1
+fi
+
+if ! command -v helm > /dev/null 2>&1; then
+    echo "Error: helm is required" >&2
+    exit 1
+fi
+
+echo "Building community chart from $SRC -> $OUT (Varnish Cache $OSS_VERSION)"
+
+rm -rf "$OUT"
+mkdir -p "$(dirname "$OUT")"
+cp -r "$SRC" "$OUT"
+
+# Patch Chart.yaml: rename, update description, and set the OSS appVersion
+yq -Y --in-place \
+    --arg version "$OSS_VERSION" '
+    .name = "varnish-cache" |
+    .description = "Varnish Cache Helm Chart" |
+    .appVersion = $version
+' "$OUT/Chart.yaml"
+
+# Switch edition and image defaults, enable malloc, strip enterprise sections
+yq -Y --in-place '
+    .global.edition = "community" |
+    .server.image.repository = "docker.io/varnish" |
+    .server.malloc.enabled = true |
+    del(.server.mse) |
+    del(.server.mse4) |
+    del(.server.agent) |
+    del(.server.initAgent) |
+    del(.server.otel) |
+    del(.server.baseUrl) |
+    del(.server.licenseSecret) |
+    del(.cluster) |
+    del(.natsServer)
+' "$OUT/values.yaml"
+
+helm lint "$OUT"
+
+echo "Community chart written to $OUT"
+echo "  appVersion: $OSS_VERSION (default image: docker.io/varnish:$OSS_VERSION)"
+echo "To package: helm package $OUT --destination ./dist/packages"

--- a/ci/publish-community.sh
+++ b/ci/publish-community.sh
@@ -12,7 +12,7 @@
 #              This sets Chart.yaml appVersion and the default image tag.
 # output-dir:  defaults to ./dist/varnish-cache
 #
-# Requires yq (kislyuk/yq) and helm.
+# Requires yq (https://github.com/mikefarah/yq) and helm.
 
 set -e
 
@@ -43,16 +43,17 @@ rm -rf "$OUT"
 mkdir -p "$(dirname "$OUT")"
 cp -r "$SRC" "$OUT"
 
-# Patch Chart.yaml: rename, update description, and set the OSS appVersion
-yq -Y --in-place \
-    --arg version "$OSS_VERSION" '
+# Patch Chart.yaml: rename, update description, and set the OSS appVersion.
+# OSS_VERSION is passed via the environment so yq can reference it with strenv().
+OSS_VERSION="$OSS_VERSION" yq -i '
     .name = "varnish-cache" |
     .description = "Varnish Cache Helm Chart" |
-    .appVersion = $version
+    .appVersion = strenv(OSS_VERSION)
 ' "$OUT/Chart.yaml"
 
-# Switch edition and image defaults, enable malloc, strip enterprise sections
-yq -Y --in-place '
+# Switch edition and image defaults, enable malloc, strip enterprise-only sections.
+# go-yq preserves comments on sections that are not deleted.
+yq -i '
     .global.edition = "community" |
     .server.image.repository = "docker.io/varnish" |
     .server.malloc.enabled = true |

--- a/ci/publish-community.sh
+++ b/ci/publish-community.sh
@@ -27,7 +27,11 @@ REPO_ROOT="$(realpath "$(dirname "$0")/..")"
 SRC="$REPO_ROOT/varnish-enterprise"
 OUT="${2:-$REPO_ROOT/dist/varnish-cache}"
 
-if ! command -v yq > /dev/null 2>&1; then
+# Allow the caller to override which yq binary to use via YQ=/path/to/yq.
+# This is needed in CI where python-yq and go-yq may both be present.
+YQ="${YQ:-yq}"
+
+if ! command -v "$YQ" > /dev/null 2>&1; then
     echo "Error: yq is required (https://github.com/mikefarah/yq)" >&2
     exit 1
 fi
@@ -45,7 +49,7 @@ cp -r "$SRC" "$OUT"
 
 # Patch Chart.yaml: rename, update description, and set the OSS appVersion.
 # OSS_VERSION is passed via the environment so yq can reference it with strenv().
-OSS_VERSION="$OSS_VERSION" yq -i '
+OSS_VERSION="$OSS_VERSION" "$YQ" -i '
     .name = "varnish-cache" |
     .description = "Varnish Cache Helm Chart" |
     .appVersion = strenv(OSS_VERSION)
@@ -53,7 +57,7 @@ OSS_VERSION="$OSS_VERSION" yq -i '
 
 # Switch edition and image defaults, enable malloc, strip enterprise-only sections.
 # go-yq preserves comments on sections that are not deleted.
-yq -i '
+"$YQ" -i '
     .global.edition = "community" |
     .server.image.repository = "docker.io/varnish" |
     .server.malloc.enabled = true |

--- a/varnish-cache/test/unit/daemonset.bats
+++ b/varnish-cache/test/unit/daemonset.bats
@@ -49,7 +49,7 @@ load _helpers
         --namespace default \
         --show-only templates/daemonset.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.updateStrategy' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.updateStrategy' | tee -a /dev/stderr)
 
     [ "${actual}" == "null" ]
 }
@@ -64,7 +64,7 @@ load _helpers
         --namespace default \
         --show-only templates/daemonset.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.updateStrategy' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.updateStrategy' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}' ]
 }
@@ -84,7 +84,7 @@ rollingUpdate:
         --namespace default \
         --show-only templates/daemonset.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.updateStrategy' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.updateStrategy' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"type":"RollingUpdate","rollingUpdate":{"maxUnavailable":1}}' ]
 }

--- a/varnish-cache/test/unit/deployment.bats
+++ b/varnish-cache/test/unit/deployment.bats
@@ -32,7 +32,7 @@ load _helpers
         --namespace default \
         --show-only templates/deployment.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.strategy' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.strategy' | tee -a /dev/stderr)
 
     [ "${actual}" == "null" ]
 }
@@ -47,7 +47,7 @@ load _helpers
         --namespace default \
         --show-only templates/deployment.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.strategy' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.strategy' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}' ]
 }
@@ -67,7 +67,7 @@ rollingUpdate:
         --namespace default \
         --show-only templates/deployment.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.strategy' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.strategy' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"type":"RollingUpdate","rollingUpdate":{"maxUnavailable":1}}' ]
 }

--- a/varnish-cache/test/unit/extra.bats
+++ b/varnish-cache/test/unit/extra.bats
@@ -51,13 +51,13 @@ EOF
         . || echo "---") |
         tee -a /dev/stderr)
 
-    local actual=$(echo "$object" | yq -c | wc -l | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -o=json -I=0 | wc -l | tee -a /dev/stderr)
     [ "${actual}" == "2" ]
 
-    local actual=$(echo "$object" | yq -r -c 'select(.metadata.name == "release-name-clusterrole")' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 'select(.metadata.name == "release-name-clusterrole")' | tee -a /dev/stderr)
     [ "${actual}" == '{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"ClusterRole","metadata":{"name":"release-name-clusterrole"},"rules":[{"apiGroups":[""],"resources":["endpoints"],"verbs":["get","list","watch"]}]}' ]
 
-    local actual=$(echo "$object" | yq -r -c 'select(.metadata.name == "release-name-clusterrolebinding")' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 'select(.metadata.name == "release-name-clusterrolebinding")' | tee -a /dev/stderr)
     [ "${actual}" == '{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"ClusterRoleBinding","metadata":{"name":"release-name-clusterrolebinding"},"roleRef":{"kind":"ClusterRole","name":"release-name-clusterrole","apiGroup":"rbac.authorization.k8s.io"},"subjects":[{"kind":"ServiceAccount","name":"release-name","namespace":"default"}]}' ]
 }
 
@@ -100,12 +100,12 @@ EOF
         . || echo "---") |
         tee -a /dev/stderr)
 
-    local actual=$(echo "$object" | yq -c | wc -l | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -o=json -I=0 | wc -l | tee -a /dev/stderr)
     [ "${actual}" == "2" ]
 
-    local actual=$(echo "$object" | yq -r -c 'select(.metadata.name == "varnish-cache-clusterrole")' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 'select(.metadata.name == "varnish-cache-clusterrole")' | tee -a /dev/stderr)
     [ "${actual}" == '{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"ClusterRole","metadata":{"name":"varnish-cache-clusterrole"},"rules":[{"apiGroups":[""],"resources":["endpoints"],"verbs":["get","list","watch"]}]}' ]
 
-    local actual=$(echo "$object" | yq -r -c 'select(.metadata.name == "varnish-cache-clusterrolebinding")' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 'select(.metadata.name == "varnish-cache-clusterrolebinding")' | tee -a /dev/stderr)
     [ "${actual}" == '{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"ClusterRoleBinding","metadata":{"name":"varnish-cache-clusterrolebinding"},"roleRef":{"apiGroup":"rbac.authorization.k8s.io","kind":"ClusterRole","name":"varnish-cache-clusterrole"},"subjects":[{"kind":"ServiceAccount","name":"varnish-cache","namespace":"default"}]}' ]
 }

--- a/varnish-cache/test/unit/hpa.bats
+++ b/varnish-cache/test/unit/hpa.bats
@@ -24,24 +24,24 @@ load _helpers
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c 'length > 0' |
+        yq -r -o=json -I=0 'length > 0' |
         tee -a /dev/stderr)
     [ "${actual}" == "true" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.minReplicas' |
+        yq -r -o=json -I=0 '.spec.minReplicas' |
         tee -a /dev/stderr)
     [ "${actual}" == "2" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.maxReplicas' |
+        yq -r -o=json -I=0 '.spec.maxReplicas' |
         tee -a /dev/stderr)
     [ "${actual}" == "10" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.maxReplicas | type' |
+        yq -r -o=json -I=0 '.spec.maxReplicas | type' |
         tee -a /dev/stderr)
-    [ "${actual}" == "number" ]
+    [ "${actual}" == "!!int" ]
 }
 
 @test "HorizontalPodAutoscaler/behavior: can be set" {
@@ -57,7 +57,7 @@ load _helpers
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.behavior' |
+        yq -r -o=json -I=0 '.spec.behavior' |
         tee -a /dev/stderr)
     [ "${actual}" == '{"scaleDown":{"policies":[{"periodSeconds":60,"type":"Pods","value":4}]}}' ]
 }
@@ -80,7 +80,7 @@ scaleDown:
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.behavior' |
+        yq -r -o=json -I=0 '.spec.behavior' |
         tee -a /dev/stderr)
     [ "${actual}" == '{"scaleDown":{"policies":[{"type":"Pods","value":4,"periodSeconds":60}]}}' ]
 }
@@ -99,7 +99,7 @@ scaleDown:
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.metrics' |
+        yq -r -o=json -I=0 '.spec.metrics' |
         tee -a /dev/stderr)
     [ "${actual}" == '[{"resource":{"name":"cpu","target":{"averageUtilization":50,"type":"Utilization"}},"type":"Resource"}]' ]
 }
@@ -123,7 +123,7 @@ scaleDown:
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.metrics' |
+        yq -r -o=json -I=0 '.spec.metrics' |
         tee -a /dev/stderr)
     [ "${actual}" == '[{"type":"Resources","resource":{"name":"cpu","target":{"type":"Utilization","averageUtilization":50}}}]' ]
 }

--- a/varnish-cache/test/unit/pdb.bats
+++ b/varnish-cache/test/unit/pdb.bats
@@ -23,22 +23,22 @@ load _helpers
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c 'length > 0' |
+        yq -r -o=json -I=0 'length > 0' |
         tee -a /dev/stderr)
     [ "${actual}" == "true" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.minAvailable' |
+        yq -r -o=json -I=0 '.spec.minAvailable' |
         tee -a /dev/stderr)
     [ "${actual}" == "30%" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.minAvailable | type' |
+        yq -r -o=json -I=0 '.spec.minAvailable | type' |
         tee -a /dev/stderr)
-    [ "${actual}" == "string" ]
+    [ "${actual}" == "!!str" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.maxUnavailable' |
+        yq -r -o=json -I=0 '.spec.maxUnavailable' |
         tee -a /dev/stderr)
     [ "${actual}" == "null" ]
 }
@@ -55,22 +55,22 @@ load _helpers
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c 'length > 0' |
+        yq -r -o=json -I=0 'length > 0' |
         tee -a /dev/stderr)
     [ "${actual}" == "true" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.minAvailable' |
+        yq -r -o=json -I=0 '.spec.minAvailable' |
         tee -a /dev/stderr)
     [ "${actual}" == "5" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.minAvailable | type' |
+        yq -r -o=json -I=0 '.spec.minAvailable | type' |
         tee -a /dev/stderr)
-    [ "${actual}" == "number" ]
+    [ "${actual}" == "!!int" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.maxUnavailable' |
+        yq -r -o=json -I=0 '.spec.maxUnavailable' |
         tee -a /dev/stderr)
     [ "${actual}" == "null" ]
 }
@@ -86,24 +86,24 @@ load _helpers
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c 'length > 0' |
+        yq -r -o=json -I=0 'length > 0' |
         tee -a /dev/stderr)
     [ "${actual}" == "true" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.minAvailable' |
+        yq -r -o=json -I=0 '.spec.minAvailable' |
         tee -a /dev/stderr)
     [ "${actual}" == "null" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.maxUnavailable' |
+        yq -r -o=json -I=0 '.spec.maxUnavailable' |
         tee -a /dev/stderr)
     [ "${actual}" == "30%" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.maxUnavailable | type' |
+        yq -r -o=json -I=0 '.spec.maxUnavailable | type' |
         tee -a /dev/stderr)
-    [ "${actual}" == "string" ]
+    [ "${actual}" == "!!str" ]
 }
 
 # Kubernetes only accept maxUnavailable as a string only for percent.
@@ -118,24 +118,24 @@ load _helpers
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c 'length > 0' |
+        yq -r -o=json -I=0 'length > 0' |
         tee -a /dev/stderr)
     [ "${actual}" == "true" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.minAvailable' |
+        yq -r -o=json -I=0 '.spec.minAvailable' |
         tee -a /dev/stderr)
     [ "${actual}" == "null" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.maxUnavailable' |
+        yq -r -o=json -I=0 '.spec.maxUnavailable' |
         tee -a /dev/stderr)
     [ "${actual}" == "5" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.maxUnavailable | type' |
+        yq -r -o=json -I=0 '.spec.maxUnavailable | type' |
         tee -a /dev/stderr)
-    [ "${actual}" == "number" ]
+    [ "${actual}" == "!!int" ]
 }
 
 @test "PodDisruptionBudget: cannot be enabled without minAvailable or maxUnavailable" {

--- a/varnish-cache/test/unit/service.bats
+++ b/varnish-cache/test/unit/service.bats
@@ -12,7 +12,7 @@ load _helpers
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.externalTrafficPolicy' |
+        yq -r -o=json -I=0 '.spec.externalTrafficPolicy' |
         tee -a /dev/stderr)
 
     [ "${actual}" == "Cluster" ]
@@ -29,7 +29,7 @@ load _helpers
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.externalTrafficPolicy' |
+        yq -r -o=json -I=0 '.spec.externalTrafficPolicy' |
         tee -a /dev/stderr)
 
     [ "${actual}" == "Local" ]

--- a/varnish-cache/test/unit/statefulset.bats
+++ b/varnish-cache/test/unit/statefulset.bats
@@ -47,7 +47,7 @@ load _helpers
         --namespace default \
         --show-only templates/statefulset.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.updateStrategy' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.updateStrategy' | tee -a /dev/stderr)
 
     [ "${actual}" == "null" ]
 }
@@ -62,7 +62,7 @@ load _helpers
         --namespace default \
         --show-only templates/statefulset.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.updateStrategy' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.updateStrategy' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}' ]
 }
@@ -82,7 +82,7 @@ rollingUpdate:
         --namespace default \
         --show-only templates/statefulset.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.updateStrategy' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.updateStrategy' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"type":"RollingUpdate","rollingUpdate":{"maxUnavailable":1}}' ]
 }
@@ -98,7 +98,7 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.volumeClaimTemplates' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.volumeClaimTemplates' | tee -a /dev/stderr)
     [ "${actual}" == 'null' ]
 }
 
@@ -116,7 +116,7 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.volumeClaimTemplates' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.volumeClaimTemplates' | tee -a /dev/stderr)
     [ "${actual}" == '[{"metadata":{"name":"hello-pv"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"10Gi"}}}}]' ]
 }
 
@@ -142,6 +142,6 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.volumeClaimTemplates' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.volumeClaimTemplates' | tee -a /dev/stderr)
     [ "${actual}" == '[{"metadata":{"name":"release-name-pv"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"10Gi"}}}}]' ]
 }

--- a/varnish-cache/test/unit_common/common.bats
+++ b/varnish-cache/test/unit_common/common.bats
@@ -14,7 +14,7 @@ template=${template:-}
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.imagePullSecrets' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.imagePullSecrets' | tee -a /dev/stderr)
     [ "${actual}" == '[{"name":"quay.io-varnish-software"}]' ]
 }
 
@@ -27,7 +27,7 @@ template=${template:-}
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.serviceAccountName' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.serviceAccountName' | tee -a /dev/stderr)
     [ "${actual}" == "release-name-varnish-cache" ]
 }
 
@@ -40,7 +40,7 @@ template=${template:-}
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.serviceAccountName' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.serviceAccountName' | tee -a /dev/stderr)
     [ "${actual}" == "default" ]
 }
 
@@ -53,7 +53,7 @@ template=${template:-}
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.securityContext' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.securityContext' | tee -a /dev/stderr)
 
     # Note: values.yaml has 'global.podSecurityContext.fsGroup=999' as the default;
     # we're testing that the values are merged and not replaced.
@@ -71,7 +71,7 @@ template=${template:-}
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
             .securityContext' | tee -a /dev/stderr)
 
@@ -96,7 +96,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
             .securityContext' | tee -a /dev/stderr)
 
@@ -118,7 +118,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
             .securityContext' | tee -a /dev/stderr)
 
@@ -142,7 +142,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
             .securityContext' | tee -a /dev/stderr)
 
@@ -160,7 +160,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.metadata.labels.hello' |
+        yq -r -o=json -I=0 '.metadata.labels.hello' |
             tee -a /dev/stderr)
     [ "${actual}" == "varnish" ]
 }
@@ -174,7 +174,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.metadata.labels.hello' |
+        yq -r -o=json -I=0 '.metadata.labels.hello' |
             tee -a /dev/stderr)
     [ "${actual}" == "release-name" ]
 }
@@ -188,7 +188,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.metadata.annotations.hello' |
+        yq -r -o=json -I=0 '.metadata.annotations.hello' |
             tee -a /dev/stderr)
     [ "${actual}" == "varnish" ]
 }
@@ -202,7 +202,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.metadata.annotations.hello' |
+        yq -r -o=json -I=0 '.metadata.annotations.hello' |
             tee -a /dev/stderr)
     [ "${actual}" == "release-name" ]
 }
@@ -216,7 +216,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.metadata.annotations.hello' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations.hello' |
             tee -a /dev/stderr)
     [ "${actual}" == "varnish" ]
 }
@@ -230,7 +230,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.metadata.annotations.hello' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations.hello' |
             tee -a /dev/stderr)
     [ "${actual}" == "release-name" ]
 }
@@ -248,7 +248,7 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.labels' |
+        yq -r -o=json -I=0 '.spec.template.metadata.labels' |
             tee -a /dev/stderr)
 
     [ "${actual}" == '{"app.kubernetes.io/instance":"release-name","app.kubernetes.io/name":"varnish-cache","foo":"bar","hello":"varnish"}' ]
@@ -272,7 +272,7 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.labels' |
+        yq -r -o=json -I=0 '.spec.template.metadata.labels' |
             tee -a /dev/stderr)
 
     [ "${actual}" == '{"app.kubernetes.io/instance":"release-name","app.kubernetes.io/name":"varnish-cache","release-name":"release-name","release-namespace":"varnish"}' ]
@@ -296,7 +296,7 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.labels' |
+        yq -r -o=json -I=0 '.spec.template.metadata.labels' |
             tee -a /dev/stderr)
 
     [ "${actual}" == '{"app.kubernetes.io/instance":"release-name","app.kubernetes.io/name":"varnish-cache","release-name":"release-name","release-namespace":"default"}' ]
@@ -315,46 +315,46 @@ release-namespace: {{ .Release.Namespace }}
     # .metadata.labels
 
     local actual=$(echo "$object" |
-        yq -r -c '.metadata.labels."app.kubernetes.io/name"' |
+        yq -r -o=json -I=0 '.metadata.labels."app.kubernetes.io/name"' |
             tee -a /dev/stderr)
     [ "${actual}" == "varnish-cache" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.metadata.labels."app.kubernetes.io/instance"' |
+        yq -r -o=json -I=0 '.metadata.labels."app.kubernetes.io/instance"' |
             tee -a /dev/stderr)
     [ "${actual}" == "release-name" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.metadata.labels."app.kubernetes.io/version"' |
+        yq -r -o=json -I=0 '.metadata.labels."app.kubernetes.io/version"' |
             tee -a /dev/stderr)
     [ "${actual}" != "" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.metadata.labels."app.kubernetes.io/managed-by"' |
+        yq -r -o=json -I=0 '.metadata.labels."app.kubernetes.io/managed-by"' |
             tee -a /dev/stderr)
     [ "${actual}" == "Helm" ]
 
     # .spec.selector.matchLabels
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.selector.matchLabels."app.kubernetes.io/name"' |
+        yq -r -o=json -I=0 '.spec.selector.matchLabels."app.kubernetes.io/name"' |
             tee -a /dev/stderr)
     [ "${actual}" == "varnish-cache" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.selector.matchLabels."app.kubernetes.io/instance"' |
+        yq -r -o=json -I=0 '.spec.selector.matchLabels."app.kubernetes.io/instance"' |
             tee -a /dev/stderr)
     [ "${actual}" == "release-name" ]
 
     # .spec.template.metadata.labels
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.labels."app.kubernetes.io/name"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.labels."app.kubernetes.io/name"' |
             tee -a /dev/stderr)
     [ "${actual}" == "varnish-cache" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.labels."app.kubernetes.io/instance"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.labels."app.kubernetes.io/instance"' |
             tee -a /dev/stderr)
     [ "${actual}" == "release-name" ]
 }
@@ -375,38 +375,39 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.ports[]? | select(.name == "http")' |
+        yq -r -o=json -I=0 '.ports[]? | select(.name == "http")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"http","containerPort":8090,"protocol":"TCP"}' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.startupProbe.tcpSocket.port' |
+        yq -r -o=json -I=0 '.startupProbe.tcpSocket.port' |
             tee -a /dev/stderr)
     [ "${actual}" == "8090" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.readinessProbe.tcpSocket.port' |
+        yq -r -o=json -I=0 '.readinessProbe.tcpSocket.port' |
             tee -a /dev/stderr)
     [ "${actual}" == "8090" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.livenessProbe.tcpSocket.port' |
+        yq -r -o=json -I=0 '.livenessProbe.tcpSocket.port' |
             tee -a /dev/stderr)
     [ "${actual}" == "8090" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '
-            .command | . as $cmd | index("-a") as $i | $cmd[$i:$i+2]' |
+        yq -o=json -I=0 '
+            .command' |
+            jq -r -c '. as $cmd | index("-a") as $i | $cmd[$i:$i+2]' |
             tee -a /dev/stderr)
     [ "${actual}" == '["-a","http=$(VARNISH_HTTP_ADDRESS):8090,HTTP"]' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.env[]? | select(.name == "VARNISH_HTTP_ADDRESS") | .valueFrom' |
+        yq -r -o=json -I=0 '.env[]? | select(.name == "VARNISH_HTTP_ADDRESS") | .valueFrom' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"fieldRef":{"fieldPath":"status.podIP"}}' ]
 }
@@ -427,27 +428,28 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.ports[]? | select(.name == "http")' |
+        yq -r -o=json -I=0 '.ports[]? | select(.name == "http")' |
             tee -a /dev/stderr)
     [ "${actual}" == "" ]
 
-    local actual=$(echo "$container" | yq -r -c '.startupProbe' | tee -a /dev/stderr)
+    local actual=$(echo "$container" | yq -r -o=json -I=0 '.startupProbe' | tee -a /dev/stderr)
     [ "${actual}" == "null" ]
 
-    local actual=$(echo "$container" | yq -r -c '.readinessProbe' | tee -a /dev/stderr)
+    local actual=$(echo "$container" | yq -r -o=json -I=0 '.readinessProbe' | tee -a /dev/stderr)
     [ "${actual}" == "null" ]
 
-    local actual=$(echo "$container" | yq -r -c '.livenessProbe' | tee -a /dev/stderr)
+    local actual=$(echo "$container" | yq -r -o=json -I=0 '.livenessProbe' | tee -a /dev/stderr)
     [ "${actual}" == "null" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '
-            .command | . as $cmd | index("-a")' |
+        yq -o=json -I=0 '
+            .command' |
+            jq -r -c '. as $cmd | index("-a")' |
             tee -a /dev/stderr)
     [ "${actual}" == "null" ]
 }
@@ -525,13 +527,14 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '
-            .command | . as $cmd | index("-T") as $i | $cmd[$i:$i+2]' |
+        yq -o=json -I=0 '
+            .command' |
+            jq -r -c '. as $cmd | index("-T") as $i | $cmd[$i:$i+2]' |
             tee -a /dev/stderr)
     [ "${actual}" == '["-T","127.0.0.1:6082"]' ]
 }
@@ -549,13 +552,14 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '
-            .command | . as $cmd | index("-T") as $i | $cmd[$i:$i+2]' |
+        yq -o=json -I=0 '
+            .command' |
+            jq -r -c '. as $cmd | index("-T") as $i | $cmd[$i:$i+2]' |
             tee -a /dev/stderr)
     [ "${actual}" == '["-T","0.0.0.0:9999"]' ]
 }
@@ -580,9 +584,10 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
-            .command | . as $cmd | indices("-a")[1] as $i | $cmd[$i:$i+5]' |
+            .command' |
+            jq -r -c '. as $cmd | indices("-a")[1] as $i | $cmd[$i:$i+5]' |
             tee -a /dev/stderr)
 
     [ "${actual}" == '["-a","proxy=:8088,PROXY","-a","proxy-sock=/tmp/varnish-proxy.sock,user=www,group=www,mode=0700,PROXY"]' ]
@@ -601,9 +606,10 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
-            .command | . as $cmd | indices("-a")[1] as $i | $cmd[$i:$i+2]' |
+            .command' |
+            jq -r -c '. as $cmd | indices("-a")[1] as $i | $cmd[$i:$i+2]' |
             tee -a /dev/stderr)
 
     [ "${actual}" == '["-a","althttp=:8888"]' ]
@@ -622,9 +628,10 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
-            .command | . as $cmd | indices("-a")[1] as $i | $cmd[$i:$i+2]' |
+            .command' |
+            jq -r -c '. as $cmd | indices("-a")[1] as $i | $cmd[$i:$i+2]' |
             tee -a /dev/stderr)
 
     [ "${actual}" == '["-a","althttp=/tmp/varnish.sock"]' ]
@@ -641,9 +648,10 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
-            .command | . as $cmd | indices("-a")[1]' |
+            .command' |
+            jq -r -c '. as $cmd | indices("-a")[1]' |
             tee -a /dev/stderr)
 
     [ "${actual}" == "null" ]
@@ -662,14 +670,14 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
             .env[]? | select(.name == "FOO")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"FOO","value":"bar"}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
             .env[]? | select(.name == "BAZ")' |
             tee -a /dev/stderr)
@@ -694,14 +702,14 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
             .env[]? | select(.name == "RELEASE_NAME")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"RELEASE_NAME","value":"release-name"}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
             .env[]? | select(.name == "RELEASE_NAMESPACE")' |
             tee -a /dev/stderr)
@@ -724,14 +732,14 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
             .env[]? | select(.name == "FOO")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"FOO","value":"bar"}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
             .env[]? | select(.name == "BAZ")' |
             tee -a /dev/stderr)
@@ -755,14 +763,14 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
             .env[]? | select(.name == "FROM_CONFIGMAP")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"FROM_CONFIGMAP","valueFrom":{"configMapKeyRef":{"key":"my-key","name":"my-configmap"}}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
             .env[]? | select(.name == "FROM_SECRET")' |
             tee -a /dev/stderr)
@@ -780,31 +788,35 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '
-            .command | . as $cmd | index("-t") as $i | $cmd[$i:$i+2]' |
+        yq -o=json -I=0 '
+            .command' |
+            jq -r -c '. as $cmd | index("-t") as $i | $cmd[$i:$i+2]' |
             tee -a /dev/stderr)
     [ "${actual}" == '["-t","120"]' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '
-            .command | . as $cmd | index("thread_pool_min=50") as $i | $cmd[$i]' |
+        yq -o=json -I=0 '
+            .command' |
+            jq -r -c '. as $cmd | index("thread_pool_min=50") as $i | $cmd[$i]' |
             tee -a /dev/stderr)
     [ "${actual}" == "thread_pool_min=50" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '
-            .command | . as $cmd | index("thread_pool_max=1000") as $i | $cmd[$i]' |
+        yq -o=json -I=0 '
+            .command' |
+            jq -r -c '. as $cmd | index("thread_pool_max=1000") as $i | $cmd[$i]' |
             tee -a /dev/stderr)
     [ "${actual}" == "thread_pool_max=1000" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '
-            .command | . as $cmd | index("thread_pool_timeout=120") as $i | $cmd[$i]' |
+        yq -o=json -I=0 '
+            .command' |
+            jq -r -c '. as $cmd | index("thread_pool_timeout=120") as $i | $cmd[$i]' |
             tee -a /dev/stderr)
     [ "${actual}" == "thread_pool_timeout=120" ]
 }
@@ -824,31 +836,35 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '
-            .command | . as $cmd | index("-t") as $i | $cmd[$i:$i+2]' |
+        yq -o=json -I=0 '
+            .command' |
+            jq -r -c '. as $cmd | index("-t") as $i | $cmd[$i:$i+2]' |
             tee -a /dev/stderr)
     [ "${actual}" == '["-t","240"]' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '
-            .command | . as $cmd | index("thread_pool_min=300") as $i | $cmd[$i]' |
+        yq -o=json -I=0 '
+            .command' |
+            jq -r -c '. as $cmd | index("thread_pool_min=300") as $i | $cmd[$i]' |
             tee -a /dev/stderr)
     [ "${actual}" == "thread_pool_min=300" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '
-            .command | . as $cmd | index("thread_pool_max=5000") as $i | $cmd[$i]' |
+        yq -o=json -I=0 '
+            .command' |
+            jq -r -c '. as $cmd | index("thread_pool_max=5000") as $i | $cmd[$i]' |
             tee -a /dev/stderr)
     [ "${actual}" == "thread_pool_max=5000" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '
-            .command | . as $cmd | index("thread_pool_timeout=500") as $i | $cmd[$i]' |
+        yq -o=json -I=0 '
+            .command' |
+            jq -r -c '. as $cmd | index("thread_pool_timeout=500") as $i | $cmd[$i]' |
             tee -a /dev/stderr)
     [ "${actual}" == "thread_pool_timeout=500" ]
 }
@@ -866,9 +882,10 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
-            .command | . as $cmd | indices("-p")[3] as $i | $cmd[$i:$i+2]' |
+            .command' |
+            jq -r -c '. as $cmd | indices("-p")[3] as $i | $cmd[$i:$i+2]' |
             tee -a /dev/stderr)
 
     [ "${actual}" == '["-p","feature=+http2"]' ]
@@ -886,9 +903,10 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
-            .command | . as $cmd | index("-d") as $i | $cmd[$i]' |
+            .command' |
+            jq -r -c '. as $cmd | index("-d") as $i | $cmd[$i]' |
             tee -a /dev/stderr)
 
     [ "${actual}" == "-d" ]
@@ -910,19 +928,21 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '
-            .command | . as $cmd | indices("-a")[1] as $i | $cmd[$i:$i+2]' |
+        yq -o=json -I=0 '
+            .command' |
+            jq -r -c '. as $cmd | indices("-a")[1] as $i | $cmd[$i:$i+2]' |
             tee -a /dev/stderr)
     [ "${actual}" == '["-a","proxy=:8088,PROXY"]' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '
-            .command | . as $cmd | indices("-p")[3] as $i | $cmd[$i:$i+2]' |
+        yq -o=json -I=0 '
+            .command' |
+            jq -r -c '. as $cmd | indices("-p")[3] as $i | $cmd[$i:$i+2]' |
             tee -a /dev/stderr)
     [ "${actual}" == '["-p","feature=+http2"]' ]
 }
@@ -942,19 +962,21 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '
-            .command | . as $cmd | indices("-a")[1] as $i | $cmd[$i:$i+2]' |
+        yq -o=json -I=0 '
+            .command' |
+            jq -r -c '. as $cmd | indices("-a")[1] as $i | $cmd[$i:$i+2]' |
             tee -a /dev/stderr)
     [ "${actual}" == '["-a","proxy=:8088,PROXY"]' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '
-            .command | . as $cmd | index("-d") as $i | $cmd[$i]' |
+        yq -o=json -I=0 '
+            .command' |
+            jq -r -c '. as $cmd | index("-d") as $i | $cmd[$i]' |
             tee -a /dev/stderr)
     [ "${actual}" == '-d' ]
 }
@@ -970,9 +992,10 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
-            .command | . as $cmd | indices("-a") | length' |
+            .command' |
+            jq -r -c '. as $cmd | indices("-a") | length' |
             tee -a /dev/stderr)
     [ "${actual}" == "1" ]
 }
@@ -990,7 +1013,7 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-hello")' |
             tee -a /dev/stderr)
 
@@ -1013,7 +1036,7 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "release-name-hello")' |
             tee -a /dev/stderr)
 
@@ -1033,7 +1056,7 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
             .volumeMounts[]? | select(.name == "varnish-data")' |
             tee -a /dev/stderr)
@@ -1057,7 +1080,7 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
             .volumeMounts[]? | select(.name == "release-name-data")' |
             tee -a /dev/stderr)
@@ -1079,7 +1102,7 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.volumes[]? | select(.name == "varnish-data")' |
             tee -a /dev/stderr)
 
@@ -1104,7 +1127,7 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.volumes[]? | select(.name == "release-name-data")' |
             tee -a /dev/stderr)
 
@@ -1123,28 +1146,29 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-secret"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-secret"' |
             tee -a /dev/stderr)
     [ "${actual}" = '4ad139339508eb77f3875735b8415516f14f388e228071faa1d2b080429cdd9b' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-secret")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-secret")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-secret","secret":{"secretName":"release-name-varnish-cache-secret"}}' ]
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '
-            .command | . as $cmd | index("-S") as $i | $cmd[$i:$i+2]' |
+        yq -o=json -I=0 '
+            .command' |
+            jq -r -c '. as $cmd | index("-S") as $i | $cmd[$i:$i+2]' |
             tee -a /dev/stderr)
     [ "${actual}" == '["-S","/etc/varnish/secret"]' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-secret")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-secret")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"release-name-config-secret","mountPath":"/etc/varnish/secret","subPath":"secret"}' ]
 }
@@ -1163,28 +1187,29 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-secret"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-secret"' |
             tee -a /dev/stderr)
     [ "${actual}" = 'null' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-secret")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-secret")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-secret","secret":{"secretName":"external-secret"}}' ]
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '
-            .command | . as $cmd | index("-S") as $i | $cmd[$i:$i+2]' |
+        yq -o=json -I=0 '
+            .command' |
+            jq -r -c '. as $cmd | index("-S") as $i | $cmd[$i:$i+2]' |
             tee -a /dev/stderr)
     [ "${actual}" == '["-S","/etc/varnish/secret"]' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-secret")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-secret")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"release-name-config-secret","mountPath":"/etc/varnish/secret","subPath":"varnish-password"}' ]
 }
@@ -1273,28 +1298,29 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-secret"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-secret"' |
             tee -a /dev/stderr)
     [ "${actual}" = 'null' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-secret")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-secret")' |
             tee -a /dev/stderr)
     [ "${actual}" = '' ]
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '
-            .command | . as $cmd | index("-S")' |
+        yq -o=json -I=0 '
+            .command' |
+            jq -r -c '. as $cmd | index("-S")' |
             tee -a /dev/stderr)
     [ "${actual}" == 'null' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-secret")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-secret")' |
             tee -a /dev/stderr)
     [ "${actual}" == '' ]
 }
@@ -1310,28 +1336,29 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-vcl"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-vcl"' |
             tee -a /dev/stderr)
     [ "${actual}" = 'null' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '' ]
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '
-            .command | . as $cmd | index("-f") as $i | $cmd[$i:$i+2]' |
+        yq -o=json -I=0 '
+            .command' |
+            jq -r -c '. as $cmd | index("-f") as $i | $cmd[$i:$i+2]' |
             tee -a /dev/stderr)
     [ "${actual}" = '["-f","/etc/varnish/default.vcl"]' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '' ]
 }
@@ -1364,28 +1391,29 @@ backend release-name {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-vcl"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-vcl"' |
             tee -a /dev/stderr)
     [ "${actual}" = 'e71c17a8bb11a3944b9029906deac70c7f3643ceec87cb1e8a304b7b8c92138d' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-vcl","configMap":{"name":"release-name-varnish-cache-vcl"}}' ]
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '
-            .command | . as $cmd | index("-f") as $i | $cmd[$i:$i+2]' |
+        yq -o=json -I=0 '
+            .command' |
+            jq -r -c '. as $cmd | index("-f") as $i | $cmd[$i:$i+2]' |
             tee -a /dev/stderr)
     [ "${actual}" = '["-f","/etc/varnish/default.vcl"]' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-vcl","mountPath":"/etc/varnish/default.vcl","subPath":"default.vcl"}' ]
 }
@@ -1419,28 +1447,29 @@ backend release-name {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-vcl"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-vcl"' |
             tee -a /dev/stderr)
     [ "${actual}" = 'e71c17a8bb11a3944b9029906deac70c7f3643ceec87cb1e8a304b7b8c92138d' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-vcl","configMap":{"name":"release-name-varnish-cache-vcl"}}' ]
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '
-            .command | . as $cmd | index("-f") as $i | $cmd[$i:$i+2]' |
+        yq -o=json -I=0 '
+            .command' |
+            jq -r -c '. as $cmd | index("-f") as $i | $cmd[$i:$i+2]' |
             tee -a /dev/stderr)
     [ "${actual}" = '["-f","/etc/varnish/default.vcl"]' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-vcl","mountPath":"/etc/varnish/default.vcl","subPath":"default.vcl"}' ]
 }
@@ -1490,43 +1519,44 @@ backend release-name {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-vcl"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-vcl"' |
             tee -a /dev/stderr)
     [ "${actual}" = 'e71c17a8bb11a3944b9029906deac70c7f3643ceec87cb1e8a304b7b8c92138d' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-vcl-main-vcl"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-vcl-main-vcl"' |
             tee -a /dev/stderr)
     [ "${actual}" = '11060980fc16de8bee3d626bfa600a13ab5db83471fd93fe60e15437f2d568b5' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-vcl","configMap":{"name":"release-name-varnish-cache-vcl"}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl-main-vcl")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl-main-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-vcl-main-vcl","configMap":{"name":"release-name-varnish-cache-vcl-main-vcl"}}' ]
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '
-            .command | . as $cmd | index("-f") as $i | $cmd[$i:$i+2]' |
+        yq -o=json -I=0 '
+            .command' |
+            jq -r -c '. as $cmd | index("-f") as $i | $cmd[$i:$i+2]' |
             tee -a /dev/stderr)
     [ "${actual}" = '["-f","/etc/varnish/default.vcl"]' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-vcl","mountPath":"/etc/varnish/default.vcl","subPath":"default.vcl"}' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl-main-vcl")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-vcl-main-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-vcl-main-vcl","mountPath":"/etc/varnish/main.vcl","subPath":"main.vcl"}' ]
 }
@@ -1577,43 +1607,44 @@ backend release-name {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-vcl"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-vcl"' |
             tee -a /dev/stderr)
     [ "${actual}" = 'e71c17a8bb11a3944b9029906deac70c7f3643ceec87cb1e8a304b7b8c92138d' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-vcl-main-vcl"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-vcl-main-vcl"' |
             tee -a /dev/stderr)
     [ "${actual}" = '11060980fc16de8bee3d626bfa600a13ab5db83471fd93fe60e15437f2d568b5' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-vcl","configMap":{"name":"release-name-varnish-cache-vcl"}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl-main-vcl")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl-main-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-vcl-main-vcl","configMap":{"name":"release-name-varnish-cache-vcl-main-vcl"}}' ]
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '
-            .command | . as $cmd | index("-f") as $i | $cmd[$i:$i+2]' |
+        yq -o=json -I=0 '
+            .command' |
+            jq -r -c '. as $cmd | index("-f") as $i | $cmd[$i:$i+2]' |
             tee -a /dev/stderr)
     [ "${actual}" = '["-f","/etc/varnish/default.vcl"]' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-vcl","mountPath":"/etc/varnish/default.vcl","subPath":"default.vcl"}' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl-main-vcl")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-vcl-main-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-vcl-main-vcl","mountPath":"/etc/varnish/main.vcl","subPath":"main.vcl"}' ]
 }
@@ -1665,43 +1696,44 @@ backend release-name {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-vcl"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-vcl"' |
             tee -a /dev/stderr)
     [ "${actual}" = 'e71c17a8bb11a3944b9029906deac70c7f3643ceec87cb1e8a304b7b8c92138d' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-vcl-main-vcl"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-vcl-main-vcl"' |
             tee -a /dev/stderr)
     [ "${actual}" = '11060980fc16de8bee3d626bfa600a13ab5db83471fd93fe60e15437f2d568b5' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-vcl","configMap":{"name":"release-name-varnish-cache-vcl"}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl-main-vcl")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl-main-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-vcl-main-vcl","configMap":{"name":"release-name-varnish-cache-vcl-main-vcl"}}' ]
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '
-            .command | . as $cmd | index("-f") as $i | $cmd[$i:$i+2]' |
+        yq -o=json -I=0 '
+            .command' |
+            jq -r -c '. as $cmd | index("-f") as $i | $cmd[$i:$i+2]' |
             tee -a /dev/stderr)
     [ "${actual}" = '["-f","/etc/varnish/varnish.vcl"]' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-vcl","mountPath":"/etc/varnish/varnish.vcl","subPath":"varnish.vcl"}' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl-main-vcl")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-vcl-main-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-vcl-main-vcl","mountPath":"/etc/varnish/main.vcl","subPath":"main.vcl"}' ]
 }
@@ -1788,18 +1820,19 @@ backend default {
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '
-            .command | . as $cmd | index("-f") as $i | $cmd[$i:$i+2]' |
+        yq -o=json -I=0 '
+            .command' |
+            jq -r -c '. as $cmd | index("-f") as $i | $cmd[$i:$i+2]' |
             tee -a /dev/stderr)
     [ "${actual}" == '["-f","/etc/varnish/varnish.vcl"]' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"release-name-config-vcl","mountPath":"/etc/varnish/varnish.vcl","subPath":"varnish.vcl"}' ]
 
@@ -1812,7 +1845,7 @@ backend default {
         . || echo "---") |
         tee -a /dev/stderr)
 
-    local actual=$(echo "$object" | yq -r -c '.data' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 '.data' | tee -a /dev/stderr)
     [ "${actual}" == '{"varnish.vcl":"\nvcl 4.1;\n\nbackend default {\n  .host = \"127.0.0.1\";\n  .port = \"8080\";\n}\n"}' ]
 }
 
@@ -1828,18 +1861,19 @@ backend default {
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '
-            .command | . as $cmd | index("-f") as $i | $cmd[$i:$i+2]' |
+        yq -o=json -I=0 '
+            .command' |
+            jq -r -c '. as $cmd | index("-f") as $i | $cmd[$i:$i+2]' |
             tee -a /dev/stderr)
     [ "${actual}" == '["-f","/etc/varnish/varnish.vcl"]' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" == '' ]
 }
@@ -1861,23 +1895,24 @@ backend default {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "varnish-vcl-tenant1")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "varnish-vcl-tenant1")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"configMap":{"name":"varnish-vcl-tenant1"},"name":"varnish-vcl-tenant1"}' ]
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '
-            .command | . as $cmd | index("-f") as $i | $cmd[$i:$i+2]' |
+        yq -o=json -I=0 '
+            .command' |
+            jq -r -c '. as $cmd | index("-f") as $i | $cmd[$i:$i+2]' |
             tee -a /dev/stderr)
     [ "${actual}" == '["-f","/etc/varnish/varnish.vcl"]' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "varnish-vcl-tenant1")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "varnish-vcl-tenant1")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"mountPath":"/etc/varnish/tenant1.vcl","name":"varnish-vcl-tenant1","subpath":"tenant1.vcl"}' ]
 }
@@ -1901,27 +1936,28 @@ vcl.use vcl_main
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-cmdfile"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-cmdfile"' |
             tee -a /dev/stderr)
     [ "${actual}" = '624d35eb30614898dff2f0a0d0b877fb27f394debc7f8316605a9208ed5b1c6d' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-cmdfile")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-cmdfile")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-cmdfile","configMap":{"name":"release-name-varnish-cache-cmdfile"}}' ]
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | . as $cmd | index("-I") as $i | $cmd[$i:$i+2]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '. as $cmd | index("-I") as $i | $cmd[$i:$i+2]' |
             tee -a /dev/stderr)
     [ "${actual}" == '["-I","/etc/varnish/cmds.cli"]' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-cmdfile")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-cmdfile")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"release-name-config-cmdfile","mountPath":"/etc/varnish/cmds.cli","subPath":"cmds.cli"}' ]
 }
@@ -1946,17 +1982,18 @@ vcl.use vcl_main
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | . as $cmd | index("-I") as $i | $cmd[$i:$i+2]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '. as $cmd | index("-I") as $i | $cmd[$i:$i+2]' |
             tee -a /dev/stderr)
     [ "${actual}" == '["-I","/etc/varnish/cmdfile"]' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-cmdfile")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-cmdfile")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"release-name-config-cmdfile","mountPath":"/etc/varnish/cmdfile","subPath":"cmds.cli"}' ]
 }
@@ -1975,17 +2012,17 @@ vcl.use vcl_main
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.image' |
+        yq -r -o=json -I=0 '.image' |
             tee -a /dev/stderr)
     [ "${actual}" == "docker-repo.local/varnish-software/varnish-plus:latest" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.imagePullPolicy' |
+        yq -r -o=json -I=0 '.imagePullPolicy' |
             tee -a /dev/stderr)
     [ "${actual}" == "Always" ]
 }
@@ -1998,7 +2035,7 @@ vcl.use vcl_main
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
             .startupProbe' | tee -a /dev/stderr)
 
@@ -2018,7 +2055,7 @@ vcl.use vcl_main
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
             .startupProbe' | tee -a /dev/stderr)
 
@@ -2039,7 +2076,7 @@ vcl.use vcl_main
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
             .startupProbe' | tee -a /dev/stderr)
 
@@ -2062,7 +2099,7 @@ vcl.use vcl_main
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
             .startupProbe' | tee -a /dev/stderr)
 
@@ -2083,7 +2120,7 @@ vcl.use vcl_main
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
             .startupProbe' | tee -a /dev/stderr)
 
@@ -2103,7 +2140,7 @@ vcl.use vcl_main
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
             .readinessProbe' | tee -a /dev/stderr)
 
@@ -2124,7 +2161,7 @@ vcl.use vcl_main
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
             .readinessProbe' | tee -a /dev/stderr)
 
@@ -2147,7 +2184,7 @@ vcl.use vcl_main
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
             .readinessProbe' | tee -a /dev/stderr)
 
@@ -2168,7 +2205,7 @@ vcl.use vcl_main
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
             .readinessProbe' | tee -a /dev/stderr)
 
@@ -2184,7 +2221,7 @@ vcl.use vcl_main
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
             .readinessProbe' | tee -a /dev/stderr)
 
@@ -2204,7 +2241,7 @@ vcl.use vcl_main
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
             .livenessProbe' | tee -a /dev/stderr)
 
@@ -2225,7 +2262,7 @@ vcl.use vcl_main
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
             .livenessProbe' | tee -a /dev/stderr)
 
@@ -2248,7 +2285,7 @@ vcl.use vcl_main
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
             .livenessProbe' | tee -a /dev/stderr)
 
@@ -2269,7 +2306,7 @@ vcl.use vcl_main
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
             .livenessProbe' | tee -a /dev/stderr)
 
@@ -2285,7 +2322,7 @@ vcl.use vcl_main
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
             .livenessProbe' | tee -a /dev/stderr)
 
@@ -2305,7 +2342,7 @@ vcl.use vcl_main
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
             .resources' | tee -a /dev/stderr)
 
@@ -2331,7 +2368,7 @@ requests:
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
             .resources' | tee -a /dev/stderr)
 
@@ -2357,7 +2394,7 @@ requests:
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
             .resources' | tee -a /dev/stderr)
 
@@ -2389,7 +2426,7 @@ requests:
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
             .resources' | tee -a /dev/stderr)
 
@@ -2404,7 +2441,7 @@ requests:
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache") |
             .resources' | tee -a /dev/stderr)
 
@@ -2420,7 +2457,7 @@ requests:
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"tier":"edge"}' ]
 }
@@ -2434,7 +2471,7 @@ requests:
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"tier":"release-name-edge"}' ]
 }
@@ -2447,7 +2484,7 @@ requests:
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
 
     [ "${actual}" == 'null' ]
 }
@@ -2463,7 +2500,7 @@ requests:
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.tolerations' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.tolerations' | tee -a /dev/stderr)
 
     [ "${actual}" == '[{"effect":"NoSchedule","key":"far-network-disk","operator":"Exists"}]' ]
 }
@@ -2483,7 +2520,7 @@ requests:
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.tolerations' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.tolerations' | tee -a /dev/stderr)
 
     [ "${actual}" == '[{"key":"ban-release-name","operator":"Exists","effect":"NoSchedule"}]' ]
 }
@@ -2496,7 +2533,7 @@ requests:
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.tolerations' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.tolerations' | tee -a /dev/stderr)
 
     [ "${actual}" == 'null' ]
 }
@@ -2511,7 +2548,7 @@ requests:
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.affinity' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.affinity' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"foo":"bar"}},"topologyKey":"kubernetes.io/hostname"}]}}' ]
 }
@@ -2535,7 +2572,7 @@ podAntiAffinity:
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.affinity' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.affinity' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"app.kubernetes.io/name":"varnish-cache","app.kubernetes.io/instance":"release-name"}},"topologyKey":"kubernetes.io/hostname"}]}}' ]
 }
@@ -2551,11 +2588,11 @@ podAntiAffinity:
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache")' |
             tee -a /dev/stderr)
 
-    local actual=$(echo "$container" | yq -r -c '.lifecycle' | tee -a /dev/stderr)
+    local actual=$(echo "$container" | yq -r -o=json -I=0 '.lifecycle' | tee -a /dev/stderr)
     [ "${actual}" == "null" ]
 }
 
@@ -2571,11 +2608,11 @@ podAntiAffinity:
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache")' |
             tee -a /dev/stderr)
 
-    local actual=$(echo "$container" | yq -r -c '.lifecycle' | tee -a /dev/stderr)
+    local actual=$(echo "$container" | yq -r -o=json -I=0 '.lifecycle' | tee -a /dev/stderr)
     [ "${actual}" == '{"preStop":{"exec":{"command":["/bin/sleep","120"]}}}' ]
 }
 
@@ -2593,11 +2630,11 @@ podAntiAffinity:
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache")' |
             tee -a /dev/stderr)
 
-    local actual=$(echo "$container" | yq -r -c '.lifecycle' | tee -a /dev/stderr)
+    local actual=$(echo "$container" | yq -r -o=json -I=0 '.lifecycle' | tee -a /dev/stderr)
     [ "${actual}" == '{"preStop":{"exec":{"command":["/bin/sleep","120"]}}}' ]
 }
 
@@ -2612,11 +2649,11 @@ podAntiAffinity:
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache")' |
             tee -a /dev/stderr)
 
-    local actual=$(echo "$container" | yq -r -c '.lifecycle' | tee -a /dev/stderr)
+    local actual=$(echo "$container" | yq -r -o=json -I=0 '.lifecycle' | tee -a /dev/stderr)
     [ "${actual}" == "null" ]
 }
 
@@ -2633,11 +2670,11 @@ podAntiAffinity:
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache")' |
             tee -a /dev/stderr)
 
-    local actual=$(echo "$container" | yq -r -c '.lifecycle' | tee -a /dev/stderr)
+    local actual=$(echo "$container" | yq -r -o=json -I=0 '.lifecycle' | tee -a /dev/stderr)
     [ "${actual}" == '{"preStop":{"exec":{"command":["/bin/sleep","120"]}}}' ]
 }
 
@@ -2655,11 +2692,11 @@ podAntiAffinity:
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache")' |
             tee -a /dev/stderr)
 
-    local actual=$(echo "$container" | yq -r -c '.lifecycle' | tee -a /dev/stderr)
+    local actual=$(echo "$container" | yq -r -o=json -I=0 '.lifecycle' | tee -a /dev/stderr)
     [[ "${actual}" == *"MEMPOOL.sess"* ]]
     [[ "${actual}" == *"sleep 5"* ]]
     [[ "${actual}" == *"sleep 30"* ]]
@@ -2676,7 +2713,7 @@ podAntiAffinity:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.terminationGracePeriodSeconds' |
             tee -a /dev/stderr)
     [ "${actual}" == "null" ]
@@ -2694,7 +2731,7 @@ podAntiAffinity:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.terminationGracePeriodSeconds' |
             tee -a /dev/stderr)
     [ "${actual}" == "120" ]
@@ -2712,7 +2749,7 @@ podAntiAffinity:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.terminationGracePeriodSeconds' |
             tee -a /dev/stderr)
     [ "${actual}" == "120" ]
@@ -2731,7 +2768,7 @@ podAntiAffinity:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.terminationGracePeriodSeconds' |
             tee -a /dev/stderr)
     [ "${actual}" == "180" ]
@@ -2751,7 +2788,7 @@ podAntiAffinity:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.terminationGracePeriodSeconds' |
             tee -a /dev/stderr)
     [ "${actual}" == "180" ]
@@ -2772,7 +2809,7 @@ podAntiAffinity:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.terminationGracePeriodSeconds' |
             tee -a /dev/stderr)
     [ "${actual}" == "180" ]
@@ -2787,7 +2824,7 @@ podAntiAffinity:
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache-ncsa")' |
             tee -a /dev/stderr)
 
@@ -2806,7 +2843,7 @@ podAntiAffinity:
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache-ncsa") |
             .securityContext' | tee -a /dev/stderr)
 
@@ -2834,7 +2871,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache-ncsa") |
             .securityContext' | tee -a /dev/stderr)
 
@@ -2859,7 +2896,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache-ncsa") |
             .securityContext' | tee -a /dev/stderr)
 
@@ -2886,7 +2923,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache-ncsa") |
             .securityContext' | tee -a /dev/stderr)
 
@@ -2907,7 +2944,7 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache-ncsa") |
             .args' |
             tee -a /dev/stderr)
@@ -2927,7 +2964,7 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache-ncsa") |
             .args' |
             tee -a /dev/stderr)
@@ -2948,7 +2985,7 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache-ncsa") |
             .image' |
             tee -a /dev/stderr)
@@ -2971,7 +3008,7 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache-ncsa") |
             .image' |
             tee -a /dev/stderr)
@@ -2987,7 +3024,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache-ncsa") |
             .startupProbe' | tee -a /dev/stderr)
 
@@ -3007,7 +3044,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache-ncsa") |
             .startupProbe' | tee -a /dev/stderr)
 
@@ -3027,7 +3064,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache-ncsa") |
             .readinessProbe' | tee -a /dev/stderr)
 
@@ -3043,7 +3080,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache-ncsa") |
             .readinessProbe' | tee -a /dev/stderr)
 
@@ -3063,7 +3100,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache-ncsa") |
             .livenessProbe' | tee -a /dev/stderr)
 
@@ -3079,7 +3116,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache-ncsa") |
             .livenessProbe' | tee -a /dev/stderr)
 
@@ -3098,7 +3135,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache-ncsa") |
             .resources' | tee -a /dev/stderr)
 
@@ -3113,7 +3150,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache-ncsa") |
             .resources' | tee -a /dev/stderr)
 
@@ -3133,7 +3170,7 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache-ncsa") |
             .volumeMounts[]? | select(.name == "varnish-data")' |
             tee -a /dev/stderr)
@@ -3157,7 +3194,7 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-cache-ncsa") |
             .volumeMounts[]? | select(.name == "release-name-data")' |
             tee -a /dev/stderr)
@@ -3205,12 +3242,12 @@ EOF
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrole"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrole"' |
             tee -a /dev/stderr)
     [ "${actual}" = 'null' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrolebinding"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrolebinding"' |
             tee -a /dev/stderr)
     [ "${actual}" = 'null' ]
 }
@@ -3257,12 +3294,12 @@ EOF
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrole"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrole"' |
             tee -a /dev/stderr)
     [ "${actual}" = 'b341e3a03d6bb568e16c2ccbfdc281924ad1a771b73fd2c4198a54a6ce568ebe' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrolebinding"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrolebinding"' |
             tee -a /dev/stderr)
     [ "${actual}" = 'ba049cef23c6407b1c3866a543d8b6cb6b52e01cc40b18774021761b3560424e' ]
 }
@@ -3307,12 +3344,12 @@ EOF
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrole"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrole"' |
             tee -a /dev/stderr)
     [ "${actual}" = 'null' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrolebinding"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrolebinding"' |
             tee -a /dev/stderr)
     [ "${actual}" = 'null' ]
 }
@@ -3359,12 +3396,12 @@ EOF
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrole"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrole"' |
             tee -a /dev/stderr)
     [ "${actual}" = 'b1d1b7f802f0736a0666b0947539726b6fec6e737307cfc44ab1880c8e62eb62' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrolebinding"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrolebinding"' |
             tee -a /dev/stderr)
     [ "${actual}" = '7823f0c2674876bd60bca3d758cb320a0ea13090ec80d5aead53cd9ce0e1a53f' ]
 }

--- a/varnish-controller-router/test/unit/configmap-powerdns.bats
+++ b/varnish-controller-router/test/unit/configmap-powerdns.bats
@@ -11,7 +11,7 @@ load _helpers
         --set 'powerdns.config.someSetting=test' \
         --show-only templates/configmap-powerdns.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.data["pdns.conf"]' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.data["pdns.conf"]' | tee -a /dev/stderr)
 
     [[ "${actual}" == *"some-setting=test"* ]]
 }
@@ -26,7 +26,7 @@ load _helpers
         --set 'powerdns.config.anotherBooleanThing=false' \
         --show-only templates/configmap-powerdns.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.data["pdns.conf"]' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.data["pdns.conf"]' | tee -a /dev/stderr)
 
     [[ "${actual}" == *"boolean-thing=yes"* ]]
     [[ "${actual}" == *"another-boolean-thing=no"* ]]
@@ -41,7 +41,7 @@ load _helpers
         --set 'powerdns.config.launch=gsqlite3' \
         --show-only templates/configmap-powerdns.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.data["pdns.conf"]' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.data["pdns.conf"]' | tee -a /dev/stderr)
 
     [[ "${actual}" == *"launch=gsqlite3"* ]]
 }
@@ -55,7 +55,7 @@ load _helpers
         --set 'powerdns.config.launch=' \
         --show-only templates/configmap-powerdns.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.data["pdns.conf"]' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.data["pdns.conf"]' | tee -a /dev/stderr)
 
     [[ "${actual}" == *"launch=remote"* ]]
 }
@@ -69,7 +69,7 @@ load _helpers
         --set 'powerdns.config.remoteConnectionString=' \
         --show-only templates/configmap-powerdns.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.data["pdns.conf"]' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.data["pdns.conf"]' | tee -a /dev/stderr)
 
     [[ "${actual}" == *"remote-connection-string=http:url=http://release-name-varnish-controller-router-dns-backend.default.svc.cluster.local:8091,post_json=1,post=1"* ]]
 }
@@ -84,7 +84,7 @@ load _helpers
         --set 'powerdns.config.remoteConnectionString=' \
         --show-only templates/configmap-powerdns.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.data["pdns.conf"]' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.data["pdns.conf"]' | tee -a /dev/stderr)
 
     [[ "${actual}" == *"remote-connection-string=http:url=http://release-name-varnish-controller-router-dns-backend.default.svc.cluster.local,post_json=1,post=1"* ]]
 }
@@ -99,7 +99,7 @@ load _helpers
         --set 'powerdns.config.remoteConnectionString=' \
         --show-only templates/configmap-powerdns.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.data["pdns.conf"]' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.data["pdns.conf"]' | tee -a /dev/stderr)
 
     [[ "${actual}" == *"remote-connection-string=http:url=https://release-name-varnish-controller-router-dns-backend.default.svc.cluster.local:8091,post_json=1,post=1"* ]]
 }
@@ -115,7 +115,7 @@ load _helpers
         --set 'powerdns.config.remoteConnectionString=' \
         --show-only templates/configmap-powerdns.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.data["pdns.conf"]' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.data["pdns.conf"]' | tee -a /dev/stderr)
 
     [[ "${actual}" == *"remote-connection-string=http:url=https://release-name-varnish-controller-router-dns-backend.default.svc.cluster.local,post_json=1,post=1"* ]]
 }

--- a/varnish-controller-router/test/unit/deployment-powerdns.bats
+++ b/varnish-controller-router/test/unit/deployment-powerdns.bats
@@ -9,7 +9,7 @@ load _helpers
         --namespace default \
         --show-only templates/deployment-powerdns.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.containers[]? | select(.name == "powerdns")' |
+        yq -r -o=json -I=0 '.spec.template.spec.containers[]? | select(.name == "powerdns")' |
             tee -a /dev/stderr)
     [ "${actual}" == "" ]
 }
@@ -22,7 +22,7 @@ load _helpers
         --set 'powerdns.enabled=true' \
         --show-only templates/deployment-powerdns.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.containers[]? | select(.name == "powerdns")' |
+        yq -r -o=json -I=0 '.spec.template.spec.containers[]? | select(.name == "powerdns")' |
             tee -a /dev/stderr)
     [ "${actual}" != "" ]
 }
@@ -38,7 +38,7 @@ load _helpers
         --namespace default \
         --show-only templates/deployment-powerdns.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "powerdns") |
             .securityContext' | tee -a /dev/stderr)
 
@@ -63,7 +63,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-powerdns.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "powerdns") |
             .securityContext' | tee -a /dev/stderr)
 
@@ -85,7 +85,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-powerdns.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "powerdns") |
             .securityContext' | tee -a /dev/stderr)
 
@@ -109,7 +109,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-powerdns.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "powerdns") |
             .securityContext' | tee -a /dev/stderr)
 
@@ -132,17 +132,17 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "powerdns")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.image' |
+        yq -r -o=json -I=0 '.image' |
             tee -a /dev/stderr)
     [ "${actual}" == "docker-repo.local/powerdns/powerdns:latest" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.imagePullPolicy' |
+        yq -r -o=json -I=0 '.imagePullPolicy' |
             tee -a /dev/stderr)
     [ "${actual}" == "Always" ]
 }
@@ -156,7 +156,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-powerdns.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.imagePullSecrets' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.imagePullSecrets' | tee -a /dev/stderr)
     [ "${actual}" == '[{"name":"quay.io-varnish-software"}]' ]
 }
 
@@ -169,7 +169,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-powerdns.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.serviceAccountName' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.serviceAccountName' | tee -a /dev/stderr)
     [ "${actual}" == "release-name-varnish-controller-router" ]
 }
 
@@ -182,7 +182,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-powerdns.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.serviceAccountName' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.serviceAccountName' | tee -a /dev/stderr)
     [ "${actual}" == "default" ]
 }
 
@@ -195,7 +195,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-powerdns.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.metadata.annotations.hello' |
+        yq -r -o=json -I=0 '.metadata.annotations.hello' |
             tee -a /dev/stderr)
     [ "${actual}" == "varnish" ]
 }
@@ -209,7 +209,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-powerdns.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.metadata.annotations.hello' |
+        yq -r -o=json -I=0 '.metadata.annotations.hello' |
             tee -a /dev/stderr)
     [ "${actual}" == "release-name" ]
 }
@@ -223,7 +223,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-powerdns.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.metadata.annotations.hello' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations.hello' |
             tee -a /dev/stderr)
     [ "${actual}" == "varnish" ]
 }
@@ -237,7 +237,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-powerdns.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.metadata.annotations.hello' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations.hello' |
             tee -a /dev/stderr)
     [ "${actual}" == "release-name" ]
 }
@@ -250,7 +250,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-powerdns.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.metadata.annotations' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations' |
             tee -a /dev/stderr)
 
     # The checksum in the annotation is of
@@ -277,7 +277,7 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.labels' |
+        yq -r -o=json -I=0 '.spec.template.metadata.labels' |
             tee -a /dev/stderr)
 
     [ "${actual}" == '{"app.kubernetes.io/instance":"release-name","app.kubernetes.io/name":"varnish-controller-router-powerdns","foo":"bar","hello":"varnish"}' ]
@@ -301,7 +301,7 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.labels' |
+        yq -r -o=json -I=0 '.spec.template.metadata.labels' |
             tee -a /dev/stderr)
 
     [ "${actual}" == '{"app.kubernetes.io/instance":"release-name","app.kubernetes.io/name":"varnish-controller-router-powerdns","release-name":"release-name","release-namespace":"varnish"}' ]
@@ -325,7 +325,7 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.labels' |
+        yq -r -o=json -I=0 '.spec.template.metadata.labels' |
             tee -a /dev/stderr)
 
     [ "${actual}" == '{"app.kubernetes.io/instance":"release-name","app.kubernetes.io/name":"varnish-controller-router-powerdns","release-name":"release-name","release-namespace":"default"}' ]
@@ -344,46 +344,46 @@ release-namespace: {{ .Release.Namespace }}
     # .metadata.labels
 
     local actual=$(echo "$object" |
-        yq -r -c '.metadata.labels."app.kubernetes.io/name"' |
+        yq -r -o=json -I=0 '.metadata.labels."app.kubernetes.io/name"' |
             tee -a /dev/stderr)
     [ "${actual}" == "varnish-controller-router-powerdns" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.metadata.labels."app.kubernetes.io/instance"' |
+        yq -r -o=json -I=0 '.metadata.labels."app.kubernetes.io/instance"' |
             tee -a /dev/stderr)
     [ "${actual}" == "release-name" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.metadata.labels."app.kubernetes.io/version"' |
+        yq -r -o=json -I=0 '.metadata.labels."app.kubernetes.io/version"' |
             tee -a /dev/stderr)
     [ "${actual}" != "" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.metadata.labels."app.kubernetes.io/managed-by"' |
+        yq -r -o=json -I=0 '.metadata.labels."app.kubernetes.io/managed-by"' |
             tee -a /dev/stderr)
     [ "${actual}" == "Helm" ]
 
     # .spec.selector.matchLabels
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.selector.matchLabels."app.kubernetes.io/name"' |
+        yq -r -o=json -I=0 '.spec.selector.matchLabels."app.kubernetes.io/name"' |
             tee -a /dev/stderr)
     [ "${actual}" == "varnish-controller-router-powerdns" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.selector.matchLabels."app.kubernetes.io/instance"' |
+        yq -r -o=json -I=0 '.spec.selector.matchLabels."app.kubernetes.io/instance"' |
             tee -a /dev/stderr)
     [ "${actual}" == "release-name" ]
 
     # .spec.template.metadata.labels
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.labels."app.kubernetes.io/name"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.labels."app.kubernetes.io/name"' |
             tee -a /dev/stderr)
     [ "${actual}" == "varnish-controller-router-powerdns" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.labels."app.kubernetes.io/instance"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.labels."app.kubernetes.io/instance"' |
             tee -a /dev/stderr)
     [ "${actual}" == "release-name" ]
 }
@@ -397,7 +397,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-powerdns.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"tier":"edge"}' ]
 }
@@ -411,7 +411,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-powerdns.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"tier":"release-name-edge"}' ]
 }
@@ -424,7 +424,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-powerdns.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
 
     [ "${actual}" == 'null' ]
 }
@@ -440,7 +440,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-powerdns.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.tolerations' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.tolerations' | tee -a /dev/stderr)
 
     [ "${actual}" == '[{"effect":"NoSchedule","key":"far-network-disk","operator":"Exists"}]' ]
 }
@@ -460,7 +460,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-powerdns.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.tolerations' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.tolerations' | tee -a /dev/stderr)
 
     [ "${actual}" == '[{"key":"ban-release-name","operator":"Exists","effect":"NoSchedule"}]' ]
 }
@@ -472,7 +472,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-powerdns.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.tolerations' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.tolerations' | tee -a /dev/stderr)
 
     [ "${actual}" == 'null' ]
 }
@@ -487,7 +487,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-powerdns.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.affinity' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.affinity' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"foo":"bar"}},"topologyKey":"kubernetes.io/hostname"}]}}' ]
 }
@@ -511,7 +511,7 @@ podAntiAffinity:
         --namespace default \
         --show-only templates/deployment-powerdns.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.affinity' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.affinity' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"app.kubernetes.io/name":"varnish-controller-router-powerdns","app.kubernetes.io/instance":"release-name"}},"topologyKey":"kubernetes.io/hostname"}]}}' ]
 }
@@ -525,7 +525,7 @@ podAntiAffinity:
         --namespace default \
         --show-only templates/deployment-powerdns.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.strategy' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.strategy' | tee -a /dev/stderr)
 
     [ "${actual}" == "null" ]
 }
@@ -540,7 +540,7 @@ podAntiAffinity:
         --namespace default \
         --show-only templates/deployment-powerdns.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.strategy' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.strategy' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}' ]
 }
@@ -560,7 +560,7 @@ rollingUpdate:
         --namespace default \
         --show-only templates/deployment-powerdns.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.strategy' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.strategy' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"type":"RollingUpdate","rollingUpdate":{"maxUnavailable":1}}' ]
 }
@@ -576,14 +576,14 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "powerdns") |
             .command' |
             tee -a /dev/stderr)
     [ "${actual}" == '["/usr/bin/tini","--","/usr/local/sbin/pdns_server-startup"]' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "powerdns") |
             .args' |
             tee -a /dev/stderr)
@@ -602,14 +602,14 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "powerdns") |
             .command' |
             tee -a /dev/stderr)
     [ "${actual}" == '["/usr/bin/tini","--","/usr/local/sbin/pdns_server-startup"]' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "powerdns") |
             .args' |
             tee -a /dev/stderr)
@@ -629,14 +629,14 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "powerdns") |
             .env[]? | select(.name == "FOO")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"FOO","value":"bar"}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "powerdns") |
             .env[]? | select(.name == "BAZ")' |
             tee -a /dev/stderr)
@@ -661,14 +661,14 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "powerdns") |
             .env[]? | select(.name == "RELEASE_NAME")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"RELEASE_NAME","value":"release-name"}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "powerdns") |
             .env[]? | select(.name == "RELEASE_NAMESPACE")' |
             tee -a /dev/stderr)
@@ -690,14 +690,14 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "powerdns") |
             .env[]? | select(.name == "FOO")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"FOO","value":"bar"}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "powerdns") |
             .env[]? | select(.name == "BAZ")' |
             tee -a /dev/stderr)
@@ -721,14 +721,14 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "powerdns") |
             .env[]? | select(.name == "FROM_CONFIGMAP")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"FROM_CONFIGMAP","valueFrom":{"configMapKeyRef":{"key":"my-key","name":"my-configmap"}}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "powerdns") |
             .env[]? | select(.name == "FROM_SECRET")' |
             tee -a /dev/stderr)
@@ -748,7 +748,7 @@ rollingUpdate:
         --namespace default \
         --show-only templates/deployment-powerdns.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "powerdns") |
             .resources' | tee -a /dev/stderr)
 
@@ -774,7 +774,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-powerdns.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "powerdns") |
             .resources' | tee -a /dev/stderr)
 
@@ -800,7 +800,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-powerdns.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "powerdns") |
             .resources' | tee -a /dev/stderr)
 
@@ -832,7 +832,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-powerdns.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "powerdns") |
             .resources' | tee -a /dev/stderr)
 
@@ -847,7 +847,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-powerdns.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "powerdns") |
             .resources' | tee -a /dev/stderr)
 

--- a/varnish-controller-router/test/unit/deployment-router.bats
+++ b/varnish-controller-router/test/unit/deployment-router.bats
@@ -9,7 +9,7 @@ load _helpers
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.containers[]? | select(.name == "router")' |
+        yq -r -o=json -I=0 '.spec.template.spec.containers[]? | select(.name == "router")' |
             tee -a /dev/stderr)
     [ "${actual}" != "" ]
 }
@@ -22,7 +22,7 @@ load _helpers
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.containers[]? | select(.name == "router")' |
+        yq -r -o=json -I=0 '.spec.template.spec.containers[]? | select(.name == "router")' |
             tee -a /dev/stderr)
     [ "${actual}" == "" ]
 }
@@ -43,7 +43,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .securityContext' | tee -a /dev/stderr)
 
@@ -65,7 +65,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .securityContext' | tee -a /dev/stderr)
 
@@ -89,7 +89,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .securityContext' | tee -a /dev/stderr)
 
@@ -107,28 +107,28 @@ release-namespace: to-be-override
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_SERVER") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == '$(VARNISH_CONTROLLER_NATS_USER):$(VARNISH_CONTROLLER_NATS_PASS)@$(VARNISH_CONTROLLER_NATS_HOST)' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_USER") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == 'varnish-controller' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_PASS") | .valueFrom' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"secretKeyRef":{"name":"varnish-controller-credentials","key":"nats-varnish-password"}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_HOST") | .value' |
             tee -a /dev/stderr)
@@ -146,28 +146,28 @@ release-namespace: to-be-override
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_SERVER") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == '$(VARNISH_CONTROLLER_NATS_USER):$(VARNISH_CONTROLLER_NATS_PASS)@$(VARNISH_CONTROLLER_NATS_HOST)' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_USER") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == 'varnish-controller' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_PASS") | .valueFrom' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"secretKeyRef":{"name":"external-secret","key":"nats-password"}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_HOST") | .value' |
             tee -a /dev/stderr)
@@ -185,28 +185,28 @@ release-namespace: to-be-override
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_SERVER") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == '$(VARNISH_CONTROLLER_NATS_USER):$(VARNISH_CONTROLLER_NATS_PASS)@$(VARNISH_CONTROLLER_NATS_HOST)' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_USER") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == 'varnish-controller' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_PASS") | .valueFrom' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"secretKeyRef":{"name":"varnish-controller-credentials","key":"nats-varnish-password"}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_HOST") | .value' |
             tee -a /dev/stderr)
@@ -225,28 +225,28 @@ release-namespace: to-be-override
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_SERVER") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == '$(VARNISH_CONTROLLER_NATS_USER):$(VARNISH_CONTROLLER_NATS_PASS)@$(VARNISH_CONTROLLER_NATS_HOST)' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_USER") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == 'varnish-controller' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_PASS") | .valueFrom' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"secretKeyRef":{"name":"varnish-controller-credentials","key":"nats-varnish-password"}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_HOST") | .value' |
             tee -a /dev/stderr)
@@ -264,28 +264,28 @@ release-namespace: to-be-override
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_HOST")' |
             tee -a /dev/stderr)
     [ "${actual}" == '' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_USER")' |
             tee -a /dev/stderr)
     [ "${actual}" == '' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_PASS")' |
             tee -a /dev/stderr)
     [ "${actual}" == '' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_SERVER") | .value' |
             tee -a /dev/stderr)
@@ -317,7 +317,7 @@ release-namespace: to-be-override
         --set 'global.initContainer.tag=24.04' \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.initContainers[]? | select(.name == "router-download-geoip-asn") | .image' | tee -a /dev/stderr)
 
     [ "${actual}" == 'ubuntu:24.04' ]
@@ -333,17 +333,17 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.image' |
+        yq -r -o=json -I=0 '.image' |
             tee -a /dev/stderr)
     [ "${actual}" = "quay.io/varnish-software/varnish-controller-router:$(app_version)" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.imagePullPolicy' |
+        yq -r -o=json -I=0 '.imagePullPolicy' |
             tee -a /dev/stderr)
     [ "${actual}" = "IfNotPresent" ]
 }
@@ -360,17 +360,17 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.image' |
+        yq -r -o=json -I=0 '.image' |
             tee -a /dev/stderr)
     [ "${actual}" == "quay.io/varnish-software/varnish-controller-router:latest" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.imagePullPolicy' |
+        yq -r -o=json -I=0 '.imagePullPolicy' |
             tee -a /dev/stderr)
     [ "${actual}" == "Always" ]
 }
@@ -388,17 +388,17 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.image' |
+        yq -r -o=json -I=0 '.image' |
             tee -a /dev/stderr)
     [ "${actual}" == "docker-repo.local/varnish-software/varnish-controller-router:latest" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.imagePullPolicy' |
+        yq -r -o=json -I=0 '.imagePullPolicy' |
             tee -a /dev/stderr)
     [ "${actual}" == "Always" ]
 }
@@ -411,7 +411,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.imagePullSecrets' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.imagePullSecrets' | tee -a /dev/stderr)
     [ "${actual}" == '[{"name":"quay.io-varnish-software"}]' ]
 }
 
@@ -423,7 +423,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.serviceAccountName' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.serviceAccountName' | tee -a /dev/stderr)
     [ "${actual}" == "release-name-varnish-controller-router" ]
 }
 
@@ -435,7 +435,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.serviceAccountName' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.serviceAccountName' | tee -a /dev/stderr)
     [ "${actual}" == "default" ]
 }
 
@@ -447,7 +447,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.metadata.annotations.hello' |
+        yq -r -o=json -I=0 '.metadata.annotations.hello' |
             tee -a /dev/stderr)
     [ "${actual}" == "varnish" ]
 }
@@ -460,7 +460,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.metadata.annotations.hello' |
+        yq -r -o=json -I=0 '.metadata.annotations.hello' |
             tee -a /dev/stderr)
     [ "${actual}" == "release-name" ]
 }
@@ -473,7 +473,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.metadata.annotations.hello' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations.hello' |
             tee -a /dev/stderr)
     [ "${actual}" == "varnish" ]
 }
@@ -486,7 +486,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.metadata.annotations.hello' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations.hello' |
             tee -a /dev/stderr)
     [ "${actual}" == "release-name" ]
 }
@@ -503,7 +503,7 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.labels' |
+        yq -r -o=json -I=0 '.spec.template.metadata.labels' |
             tee -a /dev/stderr)
 
     [ "${actual}" == '{"app.kubernetes.io/instance":"release-name","app.kubernetes.io/name":"varnish-controller-router","foo":"bar","hello":"varnish"}' ]
@@ -526,7 +526,7 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.labels' |
+        yq -r -o=json -I=0 '.spec.template.metadata.labels' |
             tee -a /dev/stderr)
 
     [ "${actual}" == '{"app.kubernetes.io/instance":"release-name","app.kubernetes.io/name":"varnish-controller-router","release-name":"release-name","release-namespace":"varnish"}' ]
@@ -549,7 +549,7 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.labels' |
+        yq -r -o=json -I=0 '.spec.template.metadata.labels' |
             tee -a /dev/stderr)
 
     [ "${actual}" == '{"app.kubernetes.io/instance":"release-name","app.kubernetes.io/name":"varnish-controller-router","release-name":"release-name","release-namespace":"default"}' ]
@@ -567,46 +567,46 @@ release-namespace: {{ .Release.Namespace }}
     # .metadata.labels
 
     local actual=$(echo "$object" |
-        yq -r -c '.metadata.labels."app.kubernetes.io/name"' |
+        yq -r -o=json -I=0 '.metadata.labels."app.kubernetes.io/name"' |
             tee -a /dev/stderr)
     [ "${actual}" == "varnish-controller-router" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.metadata.labels."app.kubernetes.io/instance"' |
+        yq -r -o=json -I=0 '.metadata.labels."app.kubernetes.io/instance"' |
             tee -a /dev/stderr)
     [ "${actual}" == "release-name" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.metadata.labels."app.kubernetes.io/version"' |
+        yq -r -o=json -I=0 '.metadata.labels."app.kubernetes.io/version"' |
             tee -a /dev/stderr)
     [ "${actual}" != "" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.metadata.labels."app.kubernetes.io/managed-by"' |
+        yq -r -o=json -I=0 '.metadata.labels."app.kubernetes.io/managed-by"' |
             tee -a /dev/stderr)
     [ "${actual}" == "Helm" ]
 
     # .spec.selector.matchLabels
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.selector.matchLabels."app.kubernetes.io/name"' |
+        yq -r -o=json -I=0 '.spec.selector.matchLabels."app.kubernetes.io/name"' |
             tee -a /dev/stderr)
     [ "${actual}" == "varnish-controller-router" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.selector.matchLabels."app.kubernetes.io/instance"' |
+        yq -r -o=json -I=0 '.spec.selector.matchLabels."app.kubernetes.io/instance"' |
             tee -a /dev/stderr)
     [ "${actual}" == "release-name" ]
 
     # .spec.template.metadata.labels
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.labels."app.kubernetes.io/name"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.labels."app.kubernetes.io/name"' |
             tee -a /dev/stderr)
     [ "${actual}" == "varnish-controller-router" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.labels."app.kubernetes.io/instance"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.labels."app.kubernetes.io/instance"' |
             tee -a /dev/stderr)
     [ "${actual}" == "release-name" ]
 }
@@ -619,7 +619,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"tier":"edge"}' ]
 }
@@ -632,7 +632,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"tier":"release-name-edge"}' ]
 }
@@ -644,7 +644,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
 
     [ "${actual}" == 'null' ]
 }
@@ -659,7 +659,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.tolerations' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.tolerations' | tee -a /dev/stderr)
 
     [ "${actual}" == '[{"effect":"NoSchedule","key":"far-network-disk","operator":"Exists"}]' ]
 }
@@ -678,7 +678,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.tolerations' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.tolerations' | tee -a /dev/stderr)
 
     [ "${actual}" == '[{"key":"ban-release-name","operator":"Exists","effect":"NoSchedule"}]' ]
 }
@@ -690,7 +690,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.tolerations' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.tolerations' | tee -a /dev/stderr)
 
     [ "${actual}" == 'null' ]
 }
@@ -704,7 +704,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.affinity' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.affinity' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"foo":"bar"}},"topologyKey":"kubernetes.io/hostname"}]}}' ]
 }
@@ -727,7 +727,7 @@ podAntiAffinity:
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.affinity' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.affinity' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"app.kubernetes.io/name":"varnish-controller-router","app.kubernetes.io/instance":"release-name"}},"topologyKey":"kubernetes.io/hostname"}]}}' ]
 }
@@ -740,7 +740,7 @@ podAntiAffinity:
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.strategy' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.strategy' | tee -a /dev/stderr)
 
     [ "${actual}" == "null" ]
 }
@@ -754,7 +754,7 @@ podAntiAffinity:
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.strategy' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.strategy' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}' ]
 }
@@ -773,7 +773,7 @@ rollingUpdate:
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.strategy' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.strategy' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"type":"RollingUpdate","rollingUpdate":{"maxUnavailable":1}}' ]
 }
@@ -787,21 +787,21 @@ rollingUpdate:
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_HTTP_ROUTING") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == 'true' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_HTTP_PORT") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == '6081' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_HTTP_HOST") | .valueFrom' |
             tee -a /dev/stderr)
@@ -820,7 +820,7 @@ rollingUpdate:
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_HTTP_ROUTING") | .value' |
             tee -a /dev/stderr)
@@ -837,7 +837,7 @@ rollingUpdate:
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_HTTP_PORT") | .value' |
             tee -a /dev/stderr)
@@ -853,7 +853,7 @@ rollingUpdate:
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_HTTPS_ROUTING") | .value' |
             tee -a /dev/stderr)
@@ -870,21 +870,21 @@ rollingUpdate:
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_HTTPS_ROUTING") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == 'true' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_HTTPS_PORT") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == '6443' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_HTTPS_HOST") | .valueFrom' |
             tee -a /dev/stderr)
@@ -902,7 +902,7 @@ rollingUpdate:
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_HTTPS_PORT") | .value' |
             tee -a /dev/stderr)
@@ -918,7 +918,7 @@ rollingUpdate:
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_DNS_ROUTING") | .value' |
             tee -a /dev/stderr)
@@ -935,28 +935,28 @@ rollingUpdate:
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_DNS_ROUTING") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == 'true' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_DNS_PORT") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == '8091' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_DNS_HOST") | .valueFrom' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"fieldRef":{"fieldPath":"status.podIP"}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_DNS_TLS") | .value' |
             tee -a /dev/stderr)
@@ -974,28 +974,28 @@ rollingUpdate:
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_DNS_ROUTING") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == 'true' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_DNS_PORT") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == '8091' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_DNS_HOST") | .valueFrom' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"fieldRef":{"fieldPath":"status.podIP"}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_DNS_TLS") | .value' |
             tee -a /dev/stderr)
@@ -1013,7 +1013,7 @@ rollingUpdate:
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_DNS_PORT") | .value' |
             tee -a /dev/stderr)
@@ -1031,7 +1031,7 @@ rollingUpdate:
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_DNS_TLS") | .value' |
             tee -a /dev/stderr)
@@ -1048,14 +1048,14 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .command' |
             tee -a /dev/stderr)
     [ "${actual}" == '["/usr/bin/varnish-controller-router"]' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .args' |
             tee -a /dev/stderr)
@@ -1073,14 +1073,14 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .command' |
             tee -a /dev/stderr)
     [ "${actual}" == '["/usr/bin/varnish-controller-router"]' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .args' |
             tee -a /dev/stderr)
@@ -1100,14 +1100,14 @@ rollingUpdate:
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "EXTRA_ENV") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == '1' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "ANOTHER_EXTRA_ENV") | .value' |
             tee -a /dev/stderr)
@@ -1127,14 +1127,14 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "FOO")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"FOO","value":"bar"}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "BAZ")' |
             tee -a /dev/stderr)
@@ -1159,14 +1159,14 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "RELEASE_NAME")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"RELEASE_NAME","value":"release-name"}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "RELEASE_NAMESPACE")' |
             tee -a /dev/stderr)
@@ -1188,14 +1188,14 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "FOO")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"FOO","value":"bar"}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "BAZ")' |
             tee -a /dev/stderr)
@@ -1219,14 +1219,14 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "FROM_CONFIGMAP")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"FROM_CONFIGMAP","valueFrom":{"configMapKeyRef":{"key":"my-key","name":"my-configmap"}}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .env[]? | select(.name == "FROM_SECRET")' |
             tee -a /dev/stderr)
@@ -1246,7 +1246,7 @@ rollingUpdate:
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .resources' | tee -a /dev/stderr)
 
@@ -1272,7 +1272,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .resources' | tee -a /dev/stderr)
 
@@ -1298,7 +1298,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .resources' | tee -a /dev/stderr)
 
@@ -1330,7 +1330,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .resources' | tee -a /dev/stderr)
 
@@ -1345,7 +1345,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") |
             .resources' | tee -a /dev/stderr)
 
@@ -1359,7 +1359,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.initContainers' | tee -a /dev/stderr)
 
     [ "${actual}" == 'null' ]
@@ -1375,7 +1375,7 @@ requests:
         --set 'router.asn.mmdb_url=http://example.com/test.mmdb' \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.initContainers[]? | select(.name == "router-download-geoip-asn") | .command' | tee -a /dev/stderr)
 
     [ "${actual}" == '["sh","-c","wget -O /etc/varnish-controller-router/asn.mmdb http://example.com/test.mmdb\n"]' ]
@@ -1392,7 +1392,7 @@ requests:
         --set 'router.asn.mmdb_url=http://example.com/test.mmdb' \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.initContainers[]? | select(.name == "router-download-geoip-asn") | .command' | tee -a /dev/stderr)
 
     [ "${actual}" == '["sh","-c","wget -O /etc/varnish-controller-router/geoip.mmdb http://example.com/test.mmdb\nwget -O /etc/varnish-controller-router/asn.mmdb http://example.com/test.mmdb\n"]' ]
@@ -1407,7 +1407,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.initContainers' | tee -a /dev/stderr)
 
     [ "${actual}" == 'null' ]
@@ -1447,7 +1447,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.initContainers[]? | select(.name == "router-download-geoip-asn")' |
             tee -a /dev/stderr)
 
@@ -1463,7 +1463,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") | .env[]?|
             select(.name == "VARNISH_CONTROLLER_MMDB_FILE")' | tee -a /dev/stderr)
 
@@ -1479,7 +1479,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") | .volumeMounts[]?| select(.name == "release-name-data")' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"name":"release-name-data","mountPath":"/etc/varnish-controller-router"}' ]
@@ -1494,7 +1494,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.volumes[]? | select(.name == "release-name-data")' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"name":"release-name-data","emptyDir":{}}' ]
@@ -1507,7 +1507,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.initContainers' | tee -a /dev/stderr)
 
     [ "${actual}" == 'null' ]
@@ -1522,7 +1522,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.initContainers' | tee -a /dev/stderr)
 
     [ "${actual}" == 'null' ]
@@ -1538,7 +1538,7 @@ requests:
         --set 'router.geoIp.mmdb_url=http://example.com/test.mmdb' \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.initContainers[]? | select(.name == "router-download-geoip-asn") | .command' | tee -a /dev/stderr)
 
     [ "${actual}" == '["sh","-c","wget -O /etc/varnish-controller-router/geoip.mmdb http://example.com/test.mmdb\n"]' ]
@@ -1578,7 +1578,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.initContainers[]? | select(.name == "router-download-geoip-asn")' |
             tee -a /dev/stderr)
 
@@ -1594,7 +1594,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") | .env[]?|
             select(.name == "VARNISH_CONTROLLER_MMDB_ASN_FILE")' | tee -a /dev/stderr)
 
@@ -1610,7 +1610,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "router") | .volumeMounts[]?| select(.name == "release-name-data")' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"name":"release-name-data","mountPath":"/etc/varnish-controller-router"}' ]
@@ -1625,7 +1625,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-router.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.volumes[]? | select(.name == "release-name-data")' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"name":"release-name-data","emptyDir":{}}' ]

--- a/varnish-controller-router/test/unit/service-router-dns-backend.bats
+++ b/varnish-controller-router/test/unit/service-router-dns-backend.bats
@@ -9,7 +9,7 @@ load _helpers
         --namespace default \
         --show-only templates/service-router-dns-backend.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.metadata.name' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.metadata.name' | tee -a /dev/stderr)
 
     [ "${actual}" == "null" ]
 }
@@ -23,7 +23,7 @@ load _helpers
         --set "router.dnsService.enabled=-" \
         --show-only templates/service-router-dns-backend.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.metadata.name' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.metadata.name' | tee -a /dev/stderr)
 
     [ "${actual}" == "release-name-varnish-controller-router-dns-backend" ]
 }
@@ -37,7 +37,7 @@ load _helpers
         --set "router.dnsService.enabled=-" \
         --show-only templates/service-router-dns-backend.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.metadata.name' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.metadata.name' | tee -a /dev/stderr)
 
     [ "${actual}" == "null" ]
 }
@@ -51,7 +51,7 @@ load _helpers
         --set "router.dnsService.enabled=true" \
         --show-only templates/service-router-dns-backend.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.metadata.name' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.metadata.name' | tee -a /dev/stderr)
 
     [ "${actual}" == "null" ]
 }
@@ -65,7 +65,7 @@ load _helpers
         --set "router.dnsService.enabled=false" \
         --show-only templates/service-router-dns-backend.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.metadata.name' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.metadata.name' | tee -a /dev/stderr)
 
     [ "${actual}" == "null" ]
 }
@@ -79,7 +79,7 @@ load _helpers
         --set "router.dnsService.enabled=true" \
         --show-only templates/service-router-dns-backend.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.metadata.name' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.metadata.name' | tee -a /dev/stderr)
 
     [ "${actual}" == "release-name-varnish-controller-router-dns-backend" ]
 }
@@ -93,7 +93,7 @@ load _helpers
         --show-only templates/service-router-dns-backend.yaml \
         . || echo "---") | tee -a /dev/stderr)
 
-    local actual=$(echo "$object" | yq -r -c '.metadata.annotations' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 '.metadata.annotations' | tee -a /dev/stderr)
     [ "${actual}" == "null" ]
 }
 
@@ -107,7 +107,7 @@ load _helpers
         --show-only templates/service-router-dns-backend.yaml \
         . || echo "---") | tee -a /dev/stderr)
 
-    local actual=$(echo "$object" | yq -r -c '.metadata.annotations' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 '.metadata.annotations' | tee -a /dev/stderr)
     [ "${actual}" == '{"hello":"world"}' ]
 }
 
@@ -125,6 +125,6 @@ release-name: {{ .Release.Name }}
         --show-only templates/service-router-dns-backend.yaml \
         . || echo "---") | tee -a /dev/stderr)
 
-    local actual=$(echo "$object" | yq -r -c '.metadata.annotations' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 '.metadata.annotations' | tee -a /dev/stderr)
     [ "${actual}" == '{"release-name":"release-name"}' ]
 }

--- a/varnish-controller-router/test/unit/service-router-http.bats
+++ b/varnish-controller-router/test/unit/service-router-http.bats
@@ -9,7 +9,7 @@ load _helpers
         --namespace default \
         --show-only templates/service-router-http.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.metadata.name' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.metadata.name' | tee -a /dev/stderr)
 
     [ "${actual}" == "release-name-varnish-controller-router-http" ]
 }
@@ -23,7 +23,7 @@ load _helpers
         --set "router.httpService.enabled=-" \
         --show-only templates/service-router-http.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.metadata.name' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.metadata.name' | tee -a /dev/stderr)
 
     [ "${actual}" == "null" ]
 }
@@ -37,7 +37,7 @@ load _helpers
         --set "router.httpService.enabled=false" \
         --show-only templates/service-router-http.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.metadata.name' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.metadata.name' | tee -a /dev/stderr)
 
     [ "${actual}" == "null" ]
 }
@@ -50,7 +50,7 @@ load _helpers
         --show-only templates/service-router-http.yaml \
         . || echo "---") | tee -a /dev/stderr)
 
-    local actual=$(echo "$object" | yq -r -c '.metadata.annotations' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 '.metadata.annotations' | tee -a /dev/stderr)
     [ "${actual}" == "null" ]
 }
 
@@ -63,7 +63,7 @@ load _helpers
         --show-only templates/service-router-http.yaml \
         . || echo "---") | tee -a /dev/stderr)
 
-    local actual=$(echo "$object" | yq -r -c '.metadata.annotations' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 '.metadata.annotations' | tee -a /dev/stderr)
     [ "${actual}" == '{"hello":"world"}' ]
 }
 
@@ -80,6 +80,6 @@ release-name: {{ .Release.Name }}
         --show-only templates/service-router-http.yaml \
         . || echo "---") | tee -a /dev/stderr)
 
-    local actual=$(echo "$object" | yq -r -c '.metadata.annotations' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 '.metadata.annotations' | tee -a /dev/stderr)
     [ "${actual}" == '{"release-name":"release-name"}' ]
 }

--- a/varnish-controller-router/test/unit/service-router-management.bats
+++ b/varnish-controller-router/test/unit/service-router-management.bats
@@ -9,7 +9,7 @@ load _helpers
         --namespace default \
         --show-only templates/service-router-management.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.metadata.name' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.metadata.name' | tee -a /dev/stderr)
 
     [ "${actual}" == "null" ]
 }
@@ -23,7 +23,7 @@ load _helpers
         --set "router.managementService.enabled=-" \
         --show-only templates/service-router-management.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.metadata.name' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.metadata.name' | tee -a /dev/stderr)
 
     [ "${actual}" == "release-name-varnish-controller-router-management" ]
 }
@@ -37,7 +37,7 @@ load _helpers
         --set "router.managementService.enabled=-" \
         --show-only templates/service-router-management.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.metadata.name' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.metadata.name' | tee -a /dev/stderr)
 
     [ "${actual}" == "null" ]
 }
@@ -51,7 +51,7 @@ load _helpers
         --set "router.managementService.enabled=true" \
         --show-only templates/service-router-management.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.metadata.name' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.metadata.name' | tee -a /dev/stderr)
 
     [ "${actual}" == "null" ]
 }
@@ -65,7 +65,7 @@ load _helpers
         --set "router.managementService.enabled=false" \
         --show-only templates/service-router-management.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.metadata.name' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.metadata.name' | tee -a /dev/stderr)
 
     [ "${actual}" == "null" ]
 }
@@ -79,7 +79,7 @@ load _helpers
         --set "router.managementService.enabled=true" \
         --show-only templates/service-router-management.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.metadata.name' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.metadata.name' | tee -a /dev/stderr)
 
     [ "${actual}" == "release-name-varnish-controller-router-management" ]
 }
@@ -93,7 +93,7 @@ load _helpers
         --show-only templates/service-router-management.yaml \
         . || echo "---") | tee -a /dev/stderr)
 
-    local actual=$(echo "$object" | yq -r -c '.metadata.annotations' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 '.metadata.annotations' | tee -a /dev/stderr)
     [ "${actual}" == "null" ]
 }
 
@@ -107,7 +107,7 @@ load _helpers
         --show-only templates/service-router-management.yaml \
         . || echo "---") | tee -a /dev/stderr)
 
-    local actual=$(echo "$object" | yq -r -c '.metadata.annotations' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 '.metadata.annotations' | tee -a /dev/stderr)
     [ "${actual}" == '{"hello":"world"}' ]
 }
 
@@ -125,6 +125,6 @@ release-name: {{ .Release.Name }}
         --show-only templates/service-router-management.yaml \
         . || echo "---") | tee -a /dev/stderr)
 
-    local actual=$(echo "$object" | yq -r -c '.metadata.annotations' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 '.metadata.annotations' | tee -a /dev/stderr)
     [ "${actual}" == '{"release-name":"release-name"}' ]
 }

--- a/varnish-controller/test/unit/deployment-apigw.bats
+++ b/varnish-controller/test/unit/deployment-apigw.bats
@@ -10,7 +10,7 @@ load _helpers
         --namespace default \
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.containers[]? | select(.name == "apigw")' |
+        yq -r -o=json -I=0 '.spec.template.spec.containers[]? | select(.name == "apigw")' |
             tee -a /dev/stderr)
     [ "${actual}" != "" ]
 }
@@ -24,7 +24,7 @@ load _helpers
         --namespace default \
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.containers[]? | select(.name == "apigw")' |
+        yq -r -o=json -I=0 '.spec.template.spec.containers[]? | select(.name == "apigw")' |
             tee -a /dev/stderr)
     [ "${actual}" == "" ]
 }
@@ -40,7 +40,7 @@ load _helpers
         --namespace default \
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "apigw") |
             .securityContext' | tee -a /dev/stderr)
 
@@ -65,7 +65,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "apigw") |
             .securityContext' | tee -a /dev/stderr)
 
@@ -87,7 +87,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "apigw") |
             .securityContext' | tee -a /dev/stderr)
 
@@ -111,7 +111,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "apigw") |
             .securityContext' | tee -a /dev/stderr)
 
@@ -131,17 +131,17 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "apigw")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.image' |
+        yq -r -o=json -I=0 '.image' |
             tee -a /dev/stderr)
     [ "${actual}" = "quay.io/varnish-software/varnish-controller-api-gw:$(app_version)" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.imagePullPolicy' |
+        yq -r -o=json -I=0 '.imagePullPolicy' |
             tee -a /dev/stderr)
     [ "${actual}" = "IfNotPresent" ]
 }
@@ -159,17 +159,17 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "apigw")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.image' |
+        yq -r -o=json -I=0 '.image' |
             tee -a /dev/stderr)
     [ "${actual}" == "quay.io/varnish-software/varnish-controller-api-gw:latest" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.imagePullPolicy' |
+        yq -r -o=json -I=0 '.imagePullPolicy' |
             tee -a /dev/stderr)
     [ "${actual}" == "Always" ]
 }
@@ -188,17 +188,17 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "apigw")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.image' |
+        yq -r -o=json -I=0 '.image' |
             tee -a /dev/stderr)
     [ "${actual}" == "docker-repo.local/varnish-software/varnish-controller-apigw:latest" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.imagePullPolicy' |
+        yq -r -o=json -I=0 '.imagePullPolicy' |
             tee -a /dev/stderr)
     [ "${actual}" == "Always" ]
 }
@@ -212,7 +212,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.imagePullSecrets' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.imagePullSecrets' | tee -a /dev/stderr)
     [ "${actual}" == '[{"name":"quay.io-varnish-software"}]' ]
 }
 
@@ -225,7 +225,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.serviceAccountName' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.serviceAccountName' | tee -a /dev/stderr)
     [ "${actual}" == "release-name-varnish-controller" ]
 }
 
@@ -238,7 +238,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.serviceAccountName' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.serviceAccountName' | tee -a /dev/stderr)
     [ "${actual}" == "default" ]
 }
 
@@ -251,7 +251,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.metadata.annotations.hello' |
+        yq -r -o=json -I=0 '.metadata.annotations.hello' |
             tee -a /dev/stderr)
     [ "${actual}" == "varnish" ]
 }
@@ -265,7 +265,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.metadata.annotations.hello' |
+        yq -r -o=json -I=0 '.metadata.annotations.hello' |
             tee -a /dev/stderr)
     [ "${actual}" == "release-name" ]
 }
@@ -279,7 +279,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.metadata.annotations.hello' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations.hello' |
             tee -a /dev/stderr)
     [ "${actual}" == "varnish" ]
 }
@@ -293,7 +293,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.metadata.annotations.hello' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations.hello' |
             tee -a /dev/stderr)
     [ "${actual}" == "release-name" ]
 }
@@ -311,7 +311,7 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.labels' |
+        yq -r -o=json -I=0 '.spec.template.metadata.labels' |
             tee -a /dev/stderr)
 
     [ "${actual}" == '{"app.kubernetes.io/instance":"release-name","app.kubernetes.io/name":"varnish-controller-apigw","foo":"bar","hello":"varnish"}' ]
@@ -335,7 +335,7 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.labels' |
+        yq -r -o=json -I=0 '.spec.template.metadata.labels' |
             tee -a /dev/stderr)
 
     [ "${actual}" == '{"app.kubernetes.io/instance":"release-name","app.kubernetes.io/name":"varnish-controller-apigw","release-name":"release-name","release-namespace":"varnish"}' ]
@@ -359,7 +359,7 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.labels' |
+        yq -r -o=json -I=0 '.spec.template.metadata.labels' |
             tee -a /dev/stderr)
 
     [ "${actual}" == '{"app.kubernetes.io/instance":"release-name","app.kubernetes.io/name":"varnish-controller-apigw","release-name":"release-name","release-namespace":"default"}' ]
@@ -378,46 +378,46 @@ release-namespace: {{ .Release.Namespace }}
     # .metadata.labels
 
     local actual=$(echo "$object" |
-        yq -r -c '.metadata.labels."app.kubernetes.io/name"' |
+        yq -r -o=json -I=0 '.metadata.labels."app.kubernetes.io/name"' |
             tee -a /dev/stderr)
     [ "${actual}" == "varnish-controller-apigw" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.metadata.labels."app.kubernetes.io/instance"' |
+        yq -r -o=json -I=0 '.metadata.labels."app.kubernetes.io/instance"' |
             tee -a /dev/stderr)
     [ "${actual}" == "release-name" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.metadata.labels."app.kubernetes.io/version"' |
+        yq -r -o=json -I=0 '.metadata.labels."app.kubernetes.io/version"' |
             tee -a /dev/stderr)
     [ "${actual}" != "" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.metadata.labels."app.kubernetes.io/managed-by"' |
+        yq -r -o=json -I=0 '.metadata.labels."app.kubernetes.io/managed-by"' |
             tee -a /dev/stderr)
     [ "${actual}" == "Helm" ]
 
     # .spec.selector.matchLabels
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.selector.matchLabels."app.kubernetes.io/name"' |
+        yq -r -o=json -I=0 '.spec.selector.matchLabels."app.kubernetes.io/name"' |
             tee -a /dev/stderr)
     [ "${actual}" == "varnish-controller-apigw" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.selector.matchLabels."app.kubernetes.io/instance"' |
+        yq -r -o=json -I=0 '.spec.selector.matchLabels."app.kubernetes.io/instance"' |
             tee -a /dev/stderr)
     [ "${actual}" == "release-name" ]
 
     # .spec.template.metadata.labels
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.labels."app.kubernetes.io/name"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.labels."app.kubernetes.io/name"' |
             tee -a /dev/stderr)
     [ "${actual}" == "varnish-controller-apigw" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.labels."app.kubernetes.io/instance"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.labels."app.kubernetes.io/instance"' |
             tee -a /dev/stderr)
     [ "${actual}" == "release-name" ]
 }
@@ -432,7 +432,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"tier":"edge"}' ]
 }
@@ -446,7 +446,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"tier":"release-name-edge"}' ]
 }
@@ -459,7 +459,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
 
     [ "${actual}" == 'null' ]
 }
@@ -475,7 +475,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.tolerations' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.tolerations' | tee -a /dev/stderr)
 
     [ "${actual}" == '[{"effect":"NoSchedule","key":"far-network-disk","operator":"Exists"}]' ]
 }
@@ -495,7 +495,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.tolerations' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.tolerations' | tee -a /dev/stderr)
 
     [ "${actual}" == '[{"key":"ban-release-name","operator":"Exists","effect":"NoSchedule"}]' ]
 }
@@ -508,7 +508,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.tolerations' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.tolerations' | tee -a /dev/stderr)
 
     [ "${actual}" == 'null' ]
 }
@@ -523,7 +523,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.affinity' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.affinity' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"foo":"bar"}},"topologyKey":"kubernetes.io/hostname"}]}}' ]
 }
@@ -547,7 +547,7 @@ podAntiAffinity:
         --namespace default \
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.affinity' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.affinity' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"app.kubernetes.io/name":"varnish-controller","app.kubernetes.io/instance":"release-name"}},"topologyKey":"kubernetes.io/hostname"}]}}' ]
 }
@@ -561,7 +561,7 @@ podAntiAffinity:
         --namespace default \
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.strategy' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.strategy' | tee -a /dev/stderr)
 
     [ "${actual}" == "null" ]
 }
@@ -576,7 +576,7 @@ podAntiAffinity:
         --namespace default \
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.strategy' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.strategy' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}' ]
 }
@@ -596,7 +596,7 @@ rollingUpdate:
         --namespace default \
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.strategy' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.strategy' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"type":"RollingUpdate","rollingUpdate":{"maxUnavailable":1}}' ]
 }
@@ -609,7 +609,7 @@ rollingUpdate:
         --namespace default \
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "apigw") |
             .startupProbe' | tee -a /dev/stderr)
 
@@ -629,7 +629,7 @@ rollingUpdate:
         --namespace default \
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "apigw") |
             .startupProbe' | tee -a /dev/stderr)
 
@@ -650,7 +650,7 @@ rollingUpdate:
         --namespace default \
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "apigw") |
             .startupProbe' | tee -a /dev/stderr)
 
@@ -670,7 +670,7 @@ rollingUpdate:
         --namespace default \
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "apigw") |
             .readinessProbe' | tee -a /dev/stderr)
 
@@ -686,7 +686,7 @@ rollingUpdate:
         --namespace default \
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "apigw") |
             .readinessProbe' | tee -a /dev/stderr)
 
@@ -702,7 +702,7 @@ rollingUpdate:
         --namespace default \
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "apigw") |
             .readinessProbe' | tee -a /dev/stderr)
 
@@ -722,7 +722,7 @@ rollingUpdate:
         --namespace default \
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "apigw") |
             .livenessProbe' | tee -a /dev/stderr)
 
@@ -738,7 +738,7 @@ rollingUpdate:
         --namespace default \
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "apigw") |
             .livenessProbe' | tee -a /dev/stderr)
 
@@ -754,7 +754,7 @@ rollingUpdate:
         --namespace default \
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "apigw") |
             .livenessProbe' | tee -a /dev/stderr)
 
@@ -772,14 +772,14 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "apigw") |
             .command' |
             tee -a /dev/stderr)
     [ "${actual}" == '["/usr/bin/varnish-controller-api-gw"]' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "apigw") |
             .args' |
             tee -a /dev/stderr)
@@ -798,14 +798,14 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "apigw") |
             .command' |
             tee -a /dev/stderr)
     [ "${actual}" == '["/usr/bin/varnish-controller-api-gw"]' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "apigw") |
             .args' |
             tee -a /dev/stderr)
@@ -825,14 +825,14 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "apigw") |
             .env[]? | select(.name == "FOO")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"FOO","value":"bar"}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "apigw") |
             .env[]? | select(.name == "BAZ")' |
             tee -a /dev/stderr)
@@ -858,14 +858,14 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "apigw") |
             .env[]? | select(.name == "RELEASE_NAME")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"RELEASE_NAME","value":"release-name"}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "apigw") |
             .env[]? | select(.name == "RELEASE_NAMESPACE")' |
             tee -a /dev/stderr)
@@ -887,14 +887,14 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "apigw") |
             .env[]? | select(.name == "FOO")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"FOO","value":"bar"}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "apigw") |
             .env[]? | select(.name == "BAZ")' |
             tee -a /dev/stderr)
@@ -918,14 +918,14 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "apigw") |
             .env[]? | select(.name == "FROM_CONFIGMAP")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"FROM_CONFIGMAP","valueFrom":{"configMapKeyRef":{"key":"my-key","name":"my-configmap"}}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "apigw") |
             .env[]? | select(.name == "FROM_SECRET")' |
             tee -a /dev/stderr)
@@ -945,7 +945,7 @@ rollingUpdate:
         --namespace default \
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "apigw") |
             .resources' | tee -a /dev/stderr)
 
@@ -971,7 +971,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "apigw") |
             .resources' | tee -a /dev/stderr)
 
@@ -997,7 +997,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "apigw") |
             .resources' | tee -a /dev/stderr)
 
@@ -1029,7 +1029,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "apigw") |
             .resources' | tee -a /dev/stderr)
 
@@ -1044,7 +1044,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "apigw") |
             .resources' | tee -a /dev/stderr)
 

--- a/varnish-controller/test/unit/deployment-brainz.bats
+++ b/varnish-controller/test/unit/deployment-brainz.bats
@@ -10,7 +10,7 @@ load _helpers
         --show-only templates/deployment-brainz.yaml \
         --set 'brainz.licenseSecret=brainz-license-secret' \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.containers[]? | select(.name == "brainz")' |
+        yq -r -o=json -I=0 '.spec.template.spec.containers[]? | select(.name == "brainz")' |
             tee -a /dev/stderr)
     [ "${actual}" != "" ]
 }
@@ -23,7 +23,7 @@ load _helpers
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.containers[]? | select(.name == "brainz")' |
+        yq -r -o=json -I=0 '.spec.template.spec.containers[]? | select(.name == "brainz")' |
             tee -a /dev/stderr)
     [ "${actual}" == "" ]
 }
@@ -44,7 +44,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .securityContext' | tee -a /dev/stderr)
 
@@ -66,7 +66,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .securityContext' | tee -a /dev/stderr)
 
@@ -90,7 +90,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .securityContext' | tee -a /dev/stderr)
 
@@ -109,28 +109,28 @@ release-namespace: to-be-override
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_SERVER") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == '$(VARNISH_CONTROLLER_NATS_USER):$(VARNISH_CONTROLLER_NATS_PASS)@$(VARNISH_CONTROLLER_NATS_HOST)' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_USER") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == 'varnish-controller' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_PASS") | .valueFrom' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"secretKeyRef":{"name":"varnish-controller-credentials","key":"nats-varnish-password"}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_HOST") | .value' |
             tee -a /dev/stderr)
@@ -149,28 +149,28 @@ release-namespace: to-be-override
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_SERVER") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == '$(VARNISH_CONTROLLER_NATS_USER):$(VARNISH_CONTROLLER_NATS_PASS)@$(VARNISH_CONTROLLER_NATS_HOST)' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_USER") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == 'varnish-controller' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_PASS") | .valueFrom' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"secretKeyRef":{"name":"external-secret","key":"nats-password"}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_HOST") | .value' |
             tee -a /dev/stderr)
@@ -189,28 +189,28 @@ release-namespace: to-be-override
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_SERVER") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == '$(VARNISH_CONTROLLER_NATS_USER):$(VARNISH_CONTROLLER_NATS_PASS)@$(VARNISH_CONTROLLER_NATS_HOST)' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_USER") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == 'varnish-controller' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_PASS") | .valueFrom' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"secretKeyRef":{"name":"varnish-controller-credentials","key":"nats-varnish-password"}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_HOST") | .value' |
             tee -a /dev/stderr)
@@ -230,28 +230,28 @@ release-namespace: to-be-override
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_SERVER") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == '$(VARNISH_CONTROLLER_NATS_USER):$(VARNISH_CONTROLLER_NATS_PASS)@$(VARNISH_CONTROLLER_NATS_HOST)' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_USER") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == 'varnish-controller' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_PASS") | .valueFrom' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"secretKeyRef":{"name":"varnish-controller-credentials","key":"nats-varnish-password"}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_HOST") | .value' |
             tee -a /dev/stderr)
@@ -270,28 +270,28 @@ release-namespace: to-be-override
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_HOST")' |
             tee -a /dev/stderr)
     [ "${actual}" == '' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_USER")' |
             tee -a /dev/stderr)
     [ "${actual}" == '' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_PASS")' |
             tee -a /dev/stderr)
     [ "${actual}" == '' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_SERVER") | .value' |
             tee -a /dev/stderr)
@@ -339,7 +339,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.initContainers[]? | select(.name == "brainz-download-geoip") | .image' |
             tee -a /dev/stderr)
 
@@ -358,17 +358,17 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.image' |
+        yq -r -o=json -I=0 '.image' |
             tee -a /dev/stderr)
     [ "${actual}" = "quay.io/varnish-software/varnish-controller-brainz:$(app_version)" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.imagePullPolicy' |
+        yq -r -o=json -I=0 '.imagePullPolicy' |
             tee -a /dev/stderr)
     [ "${actual}" = "IfNotPresent" ]
 }
@@ -386,17 +386,17 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.image' |
+        yq -r -o=json -I=0 '.image' |
             tee -a /dev/stderr)
     [ "${actual}" == "quay.io/varnish-software/varnish-controller-brainz:latest" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.imagePullPolicy' |
+        yq -r -o=json -I=0 '.imagePullPolicy' |
             tee -a /dev/stderr)
     [ "${actual}" == "Always" ]
 }
@@ -415,17 +415,17 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.image' |
+        yq -r -o=json -I=0 '.image' |
             tee -a /dev/stderr)
     [ "${actual}" == "docker-repo.local/varnish-software/varnish-controller-brainz:latest" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.imagePullPolicy' |
+        yq -r -o=json -I=0 '.imagePullPolicy' |
             tee -a /dev/stderr)
     [ "${actual}" == "Always" ]
 }
@@ -439,7 +439,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.imagePullSecrets' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.imagePullSecrets' | tee -a /dev/stderr)
     [ "${actual}" == '[{"name":"quay.io-varnish-software"}]' ]
 }
 
@@ -452,7 +452,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.serviceAccountName' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.serviceAccountName' | tee -a /dev/stderr)
     [ "${actual}" == "release-name-varnish-controller" ]
 }
 
@@ -465,7 +465,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.serviceAccountName' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.serviceAccountName' | tee -a /dev/stderr)
     [ "${actual}" == "default" ]
 }
 
@@ -478,7 +478,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.metadata.annotations.hello' |
+        yq -r -o=json -I=0 '.metadata.annotations.hello' |
             tee -a /dev/stderr)
     [ "${actual}" == "varnish" ]
 }
@@ -492,7 +492,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.metadata.annotations.hello' |
+        yq -r -o=json -I=0 '.metadata.annotations.hello' |
             tee -a /dev/stderr)
     [ "${actual}" == "release-name" ]
 }
@@ -506,7 +506,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.metadata.annotations.hello' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations.hello' |
             tee -a /dev/stderr)
     [ "${actual}" == "varnish" ]
 }
@@ -520,7 +520,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.metadata.annotations.hello' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations.hello' |
             tee -a /dev/stderr)
     [ "${actual}" == "release-name" ]
 }
@@ -538,7 +538,7 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.labels' |
+        yq -r -o=json -I=0 '.spec.template.metadata.labels' |
             tee -a /dev/stderr)
 
     [ "${actual}" == '{"app.kubernetes.io/instance":"release-name","app.kubernetes.io/name":"varnish-controller-brainz","foo":"bar","hello":"varnish"}' ]
@@ -562,7 +562,7 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.labels' |
+        yq -r -o=json -I=0 '.spec.template.metadata.labels' |
             tee -a /dev/stderr)
 
     [ "${actual}" == '{"app.kubernetes.io/instance":"release-name","app.kubernetes.io/name":"varnish-controller-brainz","release-name":"release-name","release-namespace":"varnish"}' ]
@@ -586,7 +586,7 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.labels' |
+        yq -r -o=json -I=0 '.spec.template.metadata.labels' |
             tee -a /dev/stderr)
 
     [ "${actual}" == '{"app.kubernetes.io/instance":"release-name","app.kubernetes.io/name":"varnish-controller-brainz","release-name":"release-name","release-namespace":"default"}' ]
@@ -605,46 +605,46 @@ release-namespace: {{ .Release.Namespace }}
     # .metadata.labels
 
     local actual=$(echo "$object" |
-        yq -r -c '.metadata.labels."app.kubernetes.io/name"' |
+        yq -r -o=json -I=0 '.metadata.labels."app.kubernetes.io/name"' |
             tee -a /dev/stderr)
     [ "${actual}" == "varnish-controller-brainz" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.metadata.labels."app.kubernetes.io/instance"' |
+        yq -r -o=json -I=0 '.metadata.labels."app.kubernetes.io/instance"' |
             tee -a /dev/stderr)
     [ "${actual}" == "release-name" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.metadata.labels."app.kubernetes.io/version"' |
+        yq -r -o=json -I=0 '.metadata.labels."app.kubernetes.io/version"' |
             tee -a /dev/stderr)
     [ "${actual}" != "" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.metadata.labels."app.kubernetes.io/managed-by"' |
+        yq -r -o=json -I=0 '.metadata.labels."app.kubernetes.io/managed-by"' |
             tee -a /dev/stderr)
     [ "${actual}" == "Helm" ]
 
     # .spec.selector.matchLabels
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.selector.matchLabels."app.kubernetes.io/name"' |
+        yq -r -o=json -I=0 '.spec.selector.matchLabels."app.kubernetes.io/name"' |
             tee -a /dev/stderr)
     [ "${actual}" == "varnish-controller-brainz" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.selector.matchLabels."app.kubernetes.io/instance"' |
+        yq -r -o=json -I=0 '.spec.selector.matchLabels."app.kubernetes.io/instance"' |
             tee -a /dev/stderr)
     [ "${actual}" == "release-name" ]
 
     # .spec.template.metadata.labels
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.labels."app.kubernetes.io/name"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.labels."app.kubernetes.io/name"' |
             tee -a /dev/stderr)
     [ "${actual}" == "varnish-controller-brainz" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.labels."app.kubernetes.io/instance"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.labels."app.kubernetes.io/instance"' |
             tee -a /dev/stderr)
     [ "${actual}" == "release-name" ]
 }
@@ -658,7 +658,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"tier":"edge"}' ]
 }
@@ -672,7 +672,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"tier":"release-name-edge"}' ]
 }
@@ -685,7 +685,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
 
     [ "${actual}" == 'null' ]
 }
@@ -701,7 +701,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.tolerations' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.tolerations' | tee -a /dev/stderr)
 
     [ "${actual}" == '[{"effect":"NoSchedule","key":"far-network-disk","operator":"Exists"}]' ]
 }
@@ -721,7 +721,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.tolerations' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.tolerations' | tee -a /dev/stderr)
 
     [ "${actual}" == '[{"key":"ban-release-name","operator":"Exists","effect":"NoSchedule"}]' ]
 }
@@ -734,7 +734,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.tolerations' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.tolerations' | tee -a /dev/stderr)
 
     [ "${actual}" == 'null' ]
 }
@@ -749,7 +749,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.affinity' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.affinity' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"foo":"bar"}},"topologyKey":"kubernetes.io/hostname"}]}}' ]
 }
@@ -773,7 +773,7 @@ podAntiAffinity:
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.affinity' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.affinity' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"app.kubernetes.io/name":"varnish-controller","app.kubernetes.io/instance":"release-name"}},"topologyKey":"kubernetes.io/hostname"}]}}' ]
 }
@@ -787,7 +787,7 @@ podAntiAffinity:
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.strategy' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.strategy' | tee -a /dev/stderr)
 
     [ "${actual}" == "null" ]
 }
@@ -802,7 +802,7 @@ podAntiAffinity:
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.strategy' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.strategy' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}' ]
 }
@@ -822,7 +822,7 @@ rollingUpdate:
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.strategy' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.strategy' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"type":"RollingUpdate","rollingUpdate":{"maxUnavailable":1}}' ]
 }
@@ -838,20 +838,20 @@ rollingUpdate:
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") | .args' |
             tee -a /dev/stderr)
     [ "${actual}" == '["-mod-admin-user"]' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_SYSTEM_ADMIN_USER") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == 'admin' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_SYSTEM_ADMIN_PASS") | .valueFrom' |
             tee -a /dev/stderr)
@@ -871,20 +871,20 @@ rollingUpdate:
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") | .args' |
             tee -a /dev/stderr)
     [ "${actual}" == '["-mod-admin-user"]' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_SYSTEM_ADMIN_USER") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == 'admin' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_SYSTEM_ADMIN_PASS") | .value' |
             tee -a /dev/stderr)
@@ -905,20 +905,20 @@ rollingUpdate:
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") | .args' |
             tee -a /dev/stderr)
     [ "${actual}" == '["-mod-admin-user"]' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_SYSTEM_ADMIN_USER") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == 'admin' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_SYSTEM_ADMIN_PASS") | .valueFrom' |
             tee -a /dev/stderr)
@@ -983,20 +983,20 @@ rollingUpdate:
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") | .args' |
             tee -a /dev/stderr)
     [ "${actual}" == 'null' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_SYSTEM_ADMIN_USER")' |
             tee -a /dev/stderr)
     [ "${actual}" == '' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_SYSTEM_ADMIN_PASS")' |
             tee -a /dev/stderr)
@@ -1015,35 +1015,35 @@ rollingUpdate:
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_DB_NAME") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == 'varnish_controller' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_DB_SERVER") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == 'release-name-postgresql.default.svc.cluster.local' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_DB_USER") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == 'varnish-controller' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_DB_PASS") | .valueFrom' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"secretKeyRef":{"name":"external-secret","key":"postgresql-password"}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_DB_SSL") | .value' |
             tee -a /dev/stderr)
@@ -1066,35 +1066,35 @@ rollingUpdate:
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_DB_NAME") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == 'varnish-controller' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_DB_SERVER") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == 'vc-postgresql:5432' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_DB_USER") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == 'varnish' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_DB_PASS") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == 'passw0rd' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_DB_SSL") | .value' |
             tee -a /dev/stderr)
@@ -1117,7 +1117,7 @@ rollingUpdate:
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_DB_SSL") | .value' |
             tee -a /dev/stderr)
@@ -1139,7 +1139,7 @@ rollingUpdate:
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_DB_SSL") | .value' |
             tee -a /dev/stderr)
@@ -1163,35 +1163,35 @@ rollingUpdate:
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_DB_NAME") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == 'varnish-controller' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_DB_SERVER") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == 'vc-postgresql:5432' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_DB_USER") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == 'varnish' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_DB_PASS") | .valueFrom' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"secretKeyRef":{"name":"external-secret","key":"postgresql-password"}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_DB_SSL") | .value' |
             tee -a /dev/stderr)
@@ -1318,14 +1318,14 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "FOO")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"FOO","value":"bar"}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "BAZ")' |
             tee -a /dev/stderr)
@@ -1344,14 +1344,14 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .command' |
             tee -a /dev/stderr)
     [ "${actual}" == '["/usr/bin/varnish-controller-brainz"]' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .args' |
             tee -a /dev/stderr)
@@ -1371,14 +1371,14 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .command' |
             tee -a /dev/stderr)
     [ "${actual}" == '["/usr/bin/varnish-controller-brainz"]' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .args' |
             tee -a /dev/stderr)
@@ -1398,14 +1398,14 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .command' |
             tee -a /dev/stderr)
     [ "${actual}" == '["/usr/bin/varnish-controller-brainz"]' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .args' |
             tee -a /dev/stderr)
@@ -1430,14 +1430,14 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "RELEASE_NAME")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"RELEASE_NAME","value":"release-name"}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "RELEASE_NAMESPACE")' |
             tee -a /dev/stderr)
@@ -1459,14 +1459,14 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "FOO")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"FOO","value":"bar"}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "BAZ")' |
             tee -a /dev/stderr)
@@ -1490,14 +1490,14 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "FROM_CONFIGMAP")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"FROM_CONFIGMAP","valueFrom":{"configMapKeyRef":{"key":"my-key","name":"my-configmap"}}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .env[]? | select(.name == "FROM_SECRET")' |
             tee -a /dev/stderr)
@@ -1517,7 +1517,7 @@ rollingUpdate:
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .resources' | tee -a /dev/stderr)
 
@@ -1543,7 +1543,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .resources' | tee -a /dev/stderr)
 
@@ -1569,7 +1569,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .resources' | tee -a /dev/stderr)
 
@@ -1601,7 +1601,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .resources' | tee -a /dev/stderr)
 
@@ -1616,7 +1616,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .resources' | tee -a /dev/stderr)
 
@@ -1631,7 +1631,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.initContainers' | tee -a /dev/stderr)
 
     [ "${actual}" == 'null' ]
@@ -1647,7 +1647,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.initContainers' | tee -a /dev/stderr)
 
     [ "${actual}" == 'null' ]
@@ -1690,7 +1690,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.initContainers[]? | select(.name == "brainz-download-geoip")' |
             tee -a /dev/stderr)
 
@@ -1707,7 +1707,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") | .env[]?|
             select(.name == "VARNISH_CONTROLLER_MMDB_FILE_CSV")' | tee -a /dev/stderr)
 
@@ -1724,7 +1724,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") | .volumeMounts[]?| select(.name == "release-name-geoip")' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"name":"release-name-geoip","mountPath":"/etc/varnish-controller/geoip"}' ]
@@ -1740,7 +1740,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.volumes[]? | select(.name == "release-name-geoip")' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"name":"release-name-geoip","emptyDir":{}}' ]
@@ -1754,7 +1754,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .startupProbe' | tee -a /dev/stderr)
 
@@ -1774,7 +1774,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .startupProbe' | tee -a /dev/stderr)
 
@@ -1795,7 +1795,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .startupProbe' | tee -a /dev/stderr)
 
@@ -1815,7 +1815,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .readinessProbe' | tee -a /dev/stderr)
 
@@ -1831,7 +1831,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .readinessProbe' | tee -a /dev/stderr)
 
@@ -1847,7 +1847,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .readinessProbe' | tee -a /dev/stderr)
 
@@ -1867,7 +1867,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .livenessProbe' | tee -a /dev/stderr)
 
@@ -1883,7 +1883,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .livenessProbe' | tee -a /dev/stderr)
 
@@ -1899,7 +1899,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "brainz") |
             .livenessProbe' | tee -a /dev/stderr)
 

--- a/varnish-controller/test/unit/deployment-ui.bats
+++ b/varnish-controller/test/unit/deployment-ui.bats
@@ -10,7 +10,7 @@ load _helpers
         --namespace default \
         --show-only templates/deployment-ui.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.containers[]? | select(.name == "ui")' |
+        yq -r -o=json -I=0 '.spec.template.spec.containers[]? | select(.name == "ui")' |
             tee -a /dev/stderr)
     [ "${actual}" != "" ]
 }
@@ -24,7 +24,7 @@ load _helpers
         --namespace default \
         --show-only templates/deployment-ui.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.containers[]? | select(.name == "ui")' |
+        yq -r -o=json -I=0 '.spec.template.spec.containers[]? | select(.name == "ui")' |
             tee -a /dev/stderr)
     [ "${actual}" == "" ]
 }
@@ -40,7 +40,7 @@ load _helpers
         --namespace default \
         --show-only templates/deployment-ui.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "ui") |
             .securityContext' | tee -a /dev/stderr)
 
@@ -65,7 +65,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-ui.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "ui") |
             .securityContext' | tee -a /dev/stderr)
 
@@ -87,7 +87,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-ui.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "ui") |
             .securityContext' | tee -a /dev/stderr)
 
@@ -111,7 +111,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-ui.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "ui") |
             .securityContext' | tee -a /dev/stderr)
 
@@ -131,17 +131,17 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "ui")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.image' |
+        yq -r -o=json -I=0 '.image' |
             tee -a /dev/stderr)
     [ "${actual}" = "quay.io/varnish-software/varnish-controller-ui:$(app_version)" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.imagePullPolicy' |
+        yq -r -o=json -I=0 '.imagePullPolicy' |
             tee -a /dev/stderr)
     [ "${actual}" = "IfNotPresent" ]
 }
@@ -159,17 +159,17 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "ui")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.image' |
+        yq -r -o=json -I=0 '.image' |
             tee -a /dev/stderr)
     [ "${actual}" == "quay.io/varnish-software/varnish-controller-ui:latest" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.imagePullPolicy' |
+        yq -r -o=json -I=0 '.imagePullPolicy' |
             tee -a /dev/stderr)
     [ "${actual}" == "Always" ]
 }
@@ -188,17 +188,17 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "ui")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.image' |
+        yq -r -o=json -I=0 '.image' |
             tee -a /dev/stderr)
     [ "${actual}" == "docker-repo.local/varnish-software/varnish-controller-ui:latest" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.imagePullPolicy' |
+        yq -r -o=json -I=0 '.imagePullPolicy' |
             tee -a /dev/stderr)
     [ "${actual}" == "Always" ]
 }
@@ -212,7 +212,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-ui.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.imagePullSecrets' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.imagePullSecrets' | tee -a /dev/stderr)
     [ "${actual}" == '[{"name":"quay.io-varnish-software"}]' ]
 }
 
@@ -225,7 +225,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-ui.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.serviceAccountName' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.serviceAccountName' | tee -a /dev/stderr)
     [ "${actual}" == "release-name-varnish-controller" ]
 }
 
@@ -238,7 +238,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-ui.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.serviceAccountName' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.serviceAccountName' | tee -a /dev/stderr)
     [ "${actual}" == "default" ]
 }
 
@@ -251,7 +251,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-ui.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.metadata.annotations.hello' |
+        yq -r -o=json -I=0 '.metadata.annotations.hello' |
             tee -a /dev/stderr)
     [ "${actual}" == "varnish" ]
 }
@@ -265,7 +265,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-ui.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.metadata.annotations.hello' |
+        yq -r -o=json -I=0 '.metadata.annotations.hello' |
             tee -a /dev/stderr)
     [ "${actual}" == "release-name" ]
 }
@@ -279,7 +279,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-ui.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.metadata.annotations.hello' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations.hello' |
             tee -a /dev/stderr)
     [ "${actual}" == "varnish" ]
 }
@@ -293,7 +293,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only templates/deployment-ui.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.metadata.annotations.hello' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations.hello' |
             tee -a /dev/stderr)
     [ "${actual}" == "release-name" ]
 }
@@ -311,7 +311,7 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.labels' |
+        yq -r -o=json -I=0 '.spec.template.metadata.labels' |
             tee -a /dev/stderr)
 
     [ "${actual}" == '{"app.kubernetes.io/instance":"release-name","app.kubernetes.io/name":"varnish-controller-ui","foo":"bar","hello":"varnish"}' ]
@@ -335,7 +335,7 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.labels' |
+        yq -r -o=json -I=0 '.spec.template.metadata.labels' |
             tee -a /dev/stderr)
 
     [ "${actual}" == '{"app.kubernetes.io/instance":"release-name","app.kubernetes.io/name":"varnish-controller-ui","release-name":"release-name","release-namespace":"varnish"}' ]
@@ -359,7 +359,7 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.labels' |
+        yq -r -o=json -I=0 '.spec.template.metadata.labels' |
             tee -a /dev/stderr)
 
     [ "${actual}" == '{"app.kubernetes.io/instance":"release-name","app.kubernetes.io/name":"varnish-controller-ui","release-name":"release-name","release-namespace":"default"}' ]
@@ -378,46 +378,46 @@ release-namespace: {{ .Release.Namespace }}
     # .metadata.labels
 
     local actual=$(echo "$object" |
-        yq -r -c '.metadata.labels."app.kubernetes.io/name"' |
+        yq -r -o=json -I=0 '.metadata.labels."app.kubernetes.io/name"' |
             tee -a /dev/stderr)
     [ "${actual}" == "varnish-controller-ui" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.metadata.labels."app.kubernetes.io/instance"' |
+        yq -r -o=json -I=0 '.metadata.labels."app.kubernetes.io/instance"' |
             tee -a /dev/stderr)
     [ "${actual}" == "release-name" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.metadata.labels."app.kubernetes.io/version"' |
+        yq -r -o=json -I=0 '.metadata.labels."app.kubernetes.io/version"' |
             tee -a /dev/stderr)
     [ "${actual}" != "" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.metadata.labels."app.kubernetes.io/managed-by"' |
+        yq -r -o=json -I=0 '.metadata.labels."app.kubernetes.io/managed-by"' |
             tee -a /dev/stderr)
     [ "${actual}" == "Helm" ]
 
     # .spec.selector.matchLabels
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.selector.matchLabels."app.kubernetes.io/name"' |
+        yq -r -o=json -I=0 '.spec.selector.matchLabels."app.kubernetes.io/name"' |
             tee -a /dev/stderr)
     [ "${actual}" == "varnish-controller-ui" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.selector.matchLabels."app.kubernetes.io/instance"' |
+        yq -r -o=json -I=0 '.spec.selector.matchLabels."app.kubernetes.io/instance"' |
             tee -a /dev/stderr)
     [ "${actual}" == "release-name" ]
 
     # .spec.template.metadata.labels
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.labels."app.kubernetes.io/name"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.labels."app.kubernetes.io/name"' |
             tee -a /dev/stderr)
     [ "${actual}" == "varnish-controller-ui" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.labels."app.kubernetes.io/instance"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.labels."app.kubernetes.io/instance"' |
             tee -a /dev/stderr)
     [ "${actual}" == "release-name" ]
 }
@@ -432,7 +432,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-ui.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"tier":"edge"}' ]
 }
@@ -446,7 +446,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-ui.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"tier":"release-name-edge"}' ]
 }
@@ -459,7 +459,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-ui.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
 
     [ "${actual}" == 'null' ]
 }
@@ -475,7 +475,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-ui.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.tolerations' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.tolerations' | tee -a /dev/stderr)
 
     [ "${actual}" == '[{"effect":"NoSchedule","key":"far-network-disk","operator":"Exists"}]' ]
 }
@@ -495,7 +495,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-ui.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.tolerations' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.tolerations' | tee -a /dev/stderr)
 
     [ "${actual}" == '[{"key":"ban-release-name","operator":"Exists","effect":"NoSchedule"}]' ]
 }
@@ -508,7 +508,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-ui.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.tolerations' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.tolerations' | tee -a /dev/stderr)
 
     [ "${actual}" == 'null' ]
 }
@@ -523,7 +523,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only templates/deployment-ui.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.affinity' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.affinity' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"foo":"bar"}},"topologyKey":"kubernetes.io/hostname"}]}}' ]
 }
@@ -547,7 +547,7 @@ podAntiAffinity:
         --namespace default \
         --show-only templates/deployment-ui.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.affinity' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.affinity' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"app.kubernetes.io/name":"varnish-controller","app.kubernetes.io/instance":"release-name"}},"topologyKey":"kubernetes.io/hostname"}]}}' ]
 }
@@ -561,7 +561,7 @@ podAntiAffinity:
         --namespace default \
         --show-only templates/deployment-ui.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.strategy' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.strategy' | tee -a /dev/stderr)
 
     [ "${actual}" == "null" ]
 }
@@ -576,7 +576,7 @@ podAntiAffinity:
         --namespace default \
         --show-only templates/deployment-ui.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.strategy' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.strategy' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}' ]
 }
@@ -596,7 +596,7 @@ rollingUpdate:
         --namespace default \
         --show-only templates/deployment-ui.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.strategy' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.strategy' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"type":"RollingUpdate","rollingUpdate":{"maxUnavailable":1}}' ]
 }
@@ -609,7 +609,7 @@ rollingUpdate:
         --namespace default \
         --show-only templates/deployment-ui.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "ui") |
             .startupProbe' | tee -a /dev/stderr)
 
@@ -629,7 +629,7 @@ rollingUpdate:
         --namespace default \
         --show-only templates/deployment-ui.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "ui") |
             .startupProbe' | tee -a /dev/stderr)
 
@@ -649,7 +649,7 @@ rollingUpdate:
         --namespace default \
         --show-only templates/deployment-ui.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "ui") |
             .readinessProbe' | tee -a /dev/stderr)
 
@@ -665,7 +665,7 @@ rollingUpdate:
         --namespace default \
         --show-only templates/deployment-ui.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "ui") |
             .readinessProbe' | tee -a /dev/stderr)
 
@@ -685,7 +685,7 @@ rollingUpdate:
         --namespace default \
         --show-only templates/deployment-ui.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "ui") |
             .livenessProbe' | tee -a /dev/stderr)
 
@@ -701,7 +701,7 @@ rollingUpdate:
         --namespace default \
         --show-only templates/deployment-ui.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "ui") |
             .livenessProbe' | tee -a /dev/stderr)
 
@@ -719,14 +719,14 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "ui") |
             .command' |
             tee -a /dev/stderr)
     [ "${actual}" == '["/usr/bin/varnish-controller-ui"]' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "ui") |
             .args' |
             tee -a /dev/stderr)
@@ -745,14 +745,14 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "ui") |
             .command' |
             tee -a /dev/stderr)
     [ "${actual}" == '["/usr/bin/varnish-controller-ui"]' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "ui") |
             .args' |
             tee -a /dev/stderr)
@@ -772,14 +772,14 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "ui") |
             .env[]? | select(.name == "FOO")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"FOO","value":"bar"}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "ui") |
             .env[]? | select(.name == "BAZ")' |
             tee -a /dev/stderr)
@@ -804,14 +804,14 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "ui") |
             .env[]? | select(.name == "RELEASE_NAME")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"RELEASE_NAME","value":"release-name"}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "ui") |
             .env[]? | select(.name == "RELEASE_NAMESPACE")' |
             tee -a /dev/stderr)
@@ -833,14 +833,14 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "ui") |
             .env[]? | select(.name == "FOO")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"FOO","value":"bar"}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "ui") |
             .env[]? | select(.name == "BAZ")' |
             tee -a /dev/stderr)
@@ -864,14 +864,14 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "ui") |
             .env[]? | select(.name == "FROM_CONFIGMAP")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"FROM_CONFIGMAP","valueFrom":{"configMapKeyRef":{"key":"my-key","name":"my-configmap"}}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "ui") |
             .env[]? | select(.name == "FROM_SECRET")' |
             tee -a /dev/stderr)
@@ -891,7 +891,7 @@ rollingUpdate:
         --namespace default \
         --show-only templates/deployment-ui.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "ui") |
             .resources' | tee -a /dev/stderr)
 
@@ -917,7 +917,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-ui.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "ui") |
             .resources' | tee -a /dev/stderr)
 
@@ -943,7 +943,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-ui.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "ui") |
             .resources' | tee -a /dev/stderr)
 
@@ -975,7 +975,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-ui.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "ui") |
             .resources' | tee -a /dev/stderr)
 
@@ -990,7 +990,7 @@ requests:
         --namespace default \
         --show-only templates/deployment-ui.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "ui") |
             .resources' | tee -a /dev/stderr)
 

--- a/varnish-controller/test/unit/extra.bats
+++ b/varnish-controller/test/unit/extra.bats
@@ -51,13 +51,13 @@ EOF
         . || echo "---") |
         tee -a /dev/stderr)
 
-    local actual=$(echo "$object" | yq -c | wc -l | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -o=json -I=0 | wc -l | tee -a /dev/stderr)
     [ "${actual}" == "2" ]
 
-    local actual=$(echo "$object" | yq -r -c 'select(.metadata.name == "release-name-clusterrole")' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 'select(.metadata.name == "release-name-clusterrole")' | tee -a /dev/stderr)
     [ "${actual}" == '{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"ClusterRole","metadata":{"name":"release-name-clusterrole"},"rules":[{"apiGroups":[""],"resources":["endpoints"],"verbs":["get","list","watch"]}]}' ]
 
-    local actual=$(echo "$object" | yq -r -c 'select(.metadata.name == "release-name-clusterrolebinding")' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 'select(.metadata.name == "release-name-clusterrolebinding")' | tee -a /dev/stderr)
     [ "${actual}" == '{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"ClusterRoleBinding","metadata":{"name":"release-name-clusterrolebinding"},"roleRef":{"kind":"ClusterRole","name":"release-name-clusterrole","apiGroup":"rbac.authorization.k8s.io"},"subjects":[{"kind":"ServiceAccount","name":"release-name","namespace":"default"}]}' ]
 
     local objects=$((helm template \
@@ -77,12 +77,12 @@ EOF
             tee -a /dev/stderr)
 
         local actual=$(echo "$object" |
-            yq -r -c '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrole"' |
+            yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrole"' |
                 tee -a /dev/stderr)
         [ "${actual}" = 'null' ]
 
         local actual=$(echo "$object" |
-            yq -r -c '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrolebinding"' |
+            yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrolebinding"' |
                 tee -a /dev/stderr)
         [ "${actual}" = 'null' ]
     done
@@ -129,13 +129,13 @@ EOF
         . || echo "---") |
         tee -a /dev/stderr)
 
-    local actual=$(echo "$object" | yq -c | wc -l | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -o=json -I=0 | wc -l | tee -a /dev/stderr)
     [ "${actual}" == "2" ]
 
-    local actual=$(echo "$object" | yq -r -c 'select(.metadata.name == "release-name-clusterrole")' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 'select(.metadata.name == "release-name-clusterrole")' | tee -a /dev/stderr)
     [ "${actual}" == '{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"ClusterRole","metadata":{"name":"release-name-clusterrole"},"rules":[{"apiGroups":[""],"resources":["endpoints"],"verbs":["get","list","watch"]}]}' ]
 
-    local actual=$(echo "$object" | yq -r -c 'select(.metadata.name == "release-name-clusterrolebinding")' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 'select(.metadata.name == "release-name-clusterrolebinding")' | tee -a /dev/stderr)
     [ "${actual}" == '{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"ClusterRoleBinding","metadata":{"name":"release-name-clusterrolebinding"},"roleRef":{"kind":"ClusterRole","name":"release-name-clusterrole","apiGroup":"rbac.authorization.k8s.io"},"subjects":[{"kind":"ServiceAccount","name":"release-name","namespace":"default"}]}' ]
 
     local objects=$((helm template \
@@ -155,12 +155,12 @@ EOF
             tee -a /dev/stderr)
 
         local actual=$(echo "$object" |
-            yq -r -c '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrole"' |
+            yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrole"' |
                 tee -a /dev/stderr)
         [ "${actual}" = 'b341e3a03d6bb568e16c2ccbfdc281924ad1a771b73fd2c4198a54a6ce568ebe' ]
 
         local actual=$(echo "$object" |
-            yq -r -c '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrolebinding"' |
+            yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrolebinding"' |
                 tee -a /dev/stderr)
         [ "${actual}" = 'ba049cef23c6407b1c3866a543d8b6cb6b52e01cc40b18774021761b3560424e' ]
     done
@@ -205,13 +205,13 @@ EOF
         . || echo "---") |
         tee -a /dev/stderr)
 
-    local actual=$(echo "$object" | yq -c | wc -l | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -o=json -I=0 | wc -l | tee -a /dev/stderr)
     [ "${actual}" == "2" ]
 
-    local actual=$(echo "$object" | yq -r -c 'select(.metadata.name == "varnish-controller-clusterrole")' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 'select(.metadata.name == "varnish-controller-clusterrole")' | tee -a /dev/stderr)
     [ "${actual}" == '{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"ClusterRole","metadata":{"name":"varnish-controller-clusterrole"},"rules":[{"apiGroups":[""],"resources":["endpoints"],"verbs":["get","list","watch"]}]}' ]
 
-    local actual=$(echo "$object" | yq -r -c 'select(.metadata.name == "varnish-controller-clusterrolebinding")' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 'select(.metadata.name == "varnish-controller-clusterrolebinding")' | tee -a /dev/stderr)
     [ "${actual}" == '{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"ClusterRoleBinding","metadata":{"name":"varnish-controller-clusterrolebinding"},"roleRef":{"apiGroup":"rbac.authorization.k8s.io","kind":"ClusterRole","name":"varnish-controller-clusterrole"},"subjects":[{"kind":"ServiceAccount","name":"varnish-controller","namespace":"default"}]}' ]
 
     local objects=$((helm template \
@@ -231,12 +231,12 @@ EOF
             tee -a /dev/stderr)
 
         local actual=$(echo "$object" |
-            yq -r -c '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrole"' |
+            yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrole"' |
                 tee -a /dev/stderr)
         [ "${actual}" = 'null' ]
 
         local actual=$(echo "$object" |
-            yq -r -c '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrolebinding"' |
+            yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrolebinding"' |
                 tee -a /dev/stderr)
         [ "${actual}" = 'null' ]
     done
@@ -283,13 +283,13 @@ EOF
         . || echo "---") |
         tee -a /dev/stderr)
 
-    local actual=$(echo "$object" | yq -c | wc -l | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -o=json -I=0 | wc -l | tee -a /dev/stderr)
     [ "${actual}" = "2" ]
 
-    local actual=$(echo "$object" | yq -r -c 'select(.metadata.name == "varnish-controller-clusterrole")' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 'select(.metadata.name == "varnish-controller-clusterrole")' | tee -a /dev/stderr)
     [ "${actual}" == '{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"ClusterRole","metadata":{"name":"varnish-controller-clusterrole"},"rules":[{"apiGroups":[""],"resources":["endpoints"],"verbs":["get","list","watch"]}]}' ]
 
-    local actual=$(echo "$object" | yq -r -c 'select(.metadata.name == "varnish-controller-clusterrolebinding")' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 'select(.metadata.name == "varnish-controller-clusterrolebinding")' | tee -a /dev/stderr)
     [ "${actual}" == '{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"ClusterRoleBinding","metadata":{"name":"varnish-controller-clusterrolebinding"},"roleRef":{"apiGroup":"rbac.authorization.k8s.io","kind":"ClusterRole","name":"varnish-controller-clusterrole"},"subjects":[{"kind":"ServiceAccount","name":"varnish-controller","namespace":"default"}]}' ]
 
     local objects=$((helm template \
@@ -309,11 +309,11 @@ EOF
             tee -a /dev/stderr)
 
         local actual=$(echo "$object" |
-            yq -r -c '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrole"' |
+            yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrole"' |
                 tee -a /dev/stderr)
         [ "${actual}" = '61d0a598be6c41dded6fd8cfbf3f272331f50ebda6db505b6726f2e4f10aae48' ]
         local actual=$(echo "$object" |
-            yq -r -c '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrolebinding"' |
+            yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrolebinding"' |
                 tee -a /dev/stderr)
         [ "${actual}" = '4ad4a4ebf47c7cc895886ab0dd01e43217f9a7aa7a9c91038f020af4a89cd038' ]
     done

--- a/varnish-controller/test/unit/hpa-apigw.bats
+++ b/varnish-controller/test/unit/hpa-apigw.bats
@@ -25,24 +25,24 @@ load _helpers
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c 'length > 0' |
+        yq -r -o=json -I=0 'length > 0' |
         tee -a /dev/stderr)
     [ "${actual}" == "true" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.minReplicas' |
+        yq -r -o=json -I=0 '.spec.minReplicas' |
         tee -a /dev/stderr)
     [ "${actual}" == "2" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.maxReplicas' |
+        yq -r -o=json -I=0 '.spec.maxReplicas' |
         tee -a /dev/stderr)
     [ "${actual}" == "10" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.maxReplicas | type' |
+        yq -r -o=json -I=0 '.spec.maxReplicas | type' |
         tee -a /dev/stderr)
-    [ "${actual}" == "number" ]
+    [ "${actual}" == "!!int" ]
 }
 
 @test "apigw/HorizontalPodAutoscaler/behavior: can be set" {
@@ -59,7 +59,7 @@ load _helpers
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.behavior' |
+        yq -r -o=json -I=0 '.spec.behavior' |
         tee -a /dev/stderr)
     [ "${actual}" == '{"scaleDown":{"policies":[{"periodSeconds":60,"type":"Pods","value":4}]}}' ]
 }
@@ -83,7 +83,7 @@ scaleDown:
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.behavior' |
+        yq -r -o=json -I=0 '.spec.behavior' |
         tee -a /dev/stderr)
     [ "${actual}" == '{"scaleDown":{"policies":[{"type":"Pods","value":4,"periodSeconds":60}]}}' ]
 }
@@ -103,7 +103,7 @@ scaleDown:
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.metrics' |
+        yq -r -o=json -I=0 '.spec.metrics' |
         tee -a /dev/stderr)
     [ "${actual}" == '[{"resource":{"name":"cpu","target":{"averageUtilization":50,"type":"Utilization"}},"type":"Resource"}]' ]
 }
@@ -128,7 +128,7 @@ scaleDown:
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.metrics' |
+        yq -r -o=json -I=0 '.spec.metrics' |
         tee -a /dev/stderr)
     [ "${actual}" == '[{"type":"Resources","resource":{"name":"cpu","target":{"type":"Utilization","averageUtilization":50}}}]' ]
 }

--- a/varnish-controller/test/unit/hpa-brainz.bats
+++ b/varnish-controller/test/unit/hpa-brainz.bats
@@ -25,24 +25,24 @@ load _helpers
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c 'length > 0' |
+        yq -r -o=json -I=0 'length > 0' |
         tee -a /dev/stderr)
     [ "${actual}" == "true" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.minReplicas' |
+        yq -r -o=json -I=0 '.spec.minReplicas' |
         tee -a /dev/stderr)
     [ "${actual}" == "2" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.maxReplicas' |
+        yq -r -o=json -I=0 '.spec.maxReplicas' |
         tee -a /dev/stderr)
     [ "${actual}" == "10" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.maxReplicas | type' |
+        yq -r -o=json -I=0 '.spec.maxReplicas | type' |
         tee -a /dev/stderr)
-    [ "${actual}" == "number" ]
+    [ "${actual}" == "!!int" ]
 }
 
 @test "brainz/HorizontalPodAutoscaler/behavior: can be set" {
@@ -59,7 +59,7 @@ load _helpers
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.behavior' |
+        yq -r -o=json -I=0 '.spec.behavior' |
         tee -a /dev/stderr)
     [ "${actual}" == '{"scaleDown":{"policies":[{"periodSeconds":60,"type":"Pods","value":4}]}}' ]
 }
@@ -83,7 +83,7 @@ scaleDown:
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.behavior' |
+        yq -r -o=json -I=0 '.spec.behavior' |
         tee -a /dev/stderr)
     [ "${actual}" == '{"scaleDown":{"policies":[{"type":"Pods","value":4,"periodSeconds":60}]}}' ]
 }
@@ -103,7 +103,7 @@ scaleDown:
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.metrics' |
+        yq -r -o=json -I=0 '.spec.metrics' |
         tee -a /dev/stderr)
     [ "${actual}" == '[{"resource":{"name":"cpu","target":{"averageUtilization":50,"type":"Utilization"}},"type":"Resource"}]' ]
 }
@@ -128,7 +128,7 @@ scaleDown:
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.metrics' |
+        yq -r -o=json -I=0 '.spec.metrics' |
         tee -a /dev/stderr)
     [ "${actual}" == '[{"type":"Resources","resource":{"name":"cpu","target":{"type":"Utilization","averageUtilization":50}}}]' ]
 }

--- a/varnish-controller/test/unit/hpa-ui.bats
+++ b/varnish-controller/test/unit/hpa-ui.bats
@@ -25,24 +25,24 @@ load _helpers
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c 'length > 0' |
+        yq -r -o=json -I=0 'length > 0' |
         tee -a /dev/stderr)
     [ "${actual}" == "true" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.minReplicas' |
+        yq -r -o=json -I=0 '.spec.minReplicas' |
         tee -a /dev/stderr)
     [ "${actual}" == "2" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.maxReplicas' |
+        yq -r -o=json -I=0 '.spec.maxReplicas' |
         tee -a /dev/stderr)
     [ "${actual}" == "10" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.maxReplicas | type' |
+        yq -r -o=json -I=0 '.spec.maxReplicas | type' |
         tee -a /dev/stderr)
-    [ "${actual}" == "number" ]
+    [ "${actual}" == "!!int" ]
 }
 
 @test "ui/HorizontalPodAutoscaler/behavior: can be set" {
@@ -59,7 +59,7 @@ load _helpers
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.behavior' |
+        yq -r -o=json -I=0 '.spec.behavior' |
         tee -a /dev/stderr)
     [ "${actual}" == '{"scaleDown":{"policies":[{"periodSeconds":60,"type":"Pods","value":4}]}}' ]
 }
@@ -83,7 +83,7 @@ scaleDown:
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.behavior' |
+        yq -r -o=json -I=0 '.spec.behavior' |
         tee -a /dev/stderr)
     [ "${actual}" == '{"scaleDown":{"policies":[{"type":"Pods","value":4,"periodSeconds":60}]}}' ]
 }
@@ -103,7 +103,7 @@ scaleDown:
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.metrics' |
+        yq -r -o=json -I=0 '.spec.metrics' |
         tee -a /dev/stderr)
     [ "${actual}" == '[{"resource":{"name":"cpu","target":{"averageUtilization":50,"type":"Utilization"}},"type":"Resource"}]' ]
 }
@@ -128,7 +128,7 @@ scaleDown:
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.metrics' |
+        yq -r -o=json -I=0 '.spec.metrics' |
         tee -a /dev/stderr)
     [ "${actual}" == '[{"type":"Resources","resource":{"name":"cpu","target":{"type":"Utilization","averageUtilization":50}}}]' ]
 }

--- a/varnish-controller/test/unit/imagePullSecrets.bats
+++ b/varnish-controller/test/unit/imagePullSecrets.bats
@@ -12,7 +12,7 @@ load _helpers
         --show-only=charts/postgresql/templates/primary/statefulset.yaml \
         . || echo "---") | tee -a /dev/stderr)
 
-    local actual=$(echo "$object" | yq -r -c '.spec.template.spec.imagePullSecrets[0].name' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 '.spec.template.spec.imagePullSecrets[0].name' | tee -a /dev/stderr)
     [ "${actual}" == "pullSecretValue" ]
 }
 
@@ -26,7 +26,7 @@ load _helpers
         --show-only templates/deployment-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr)
 
-    local actual=$(echo "$object" | yq -r -c '.spec.template.spec.imagePullSecrets[0].name' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 '.spec.template.spec.imagePullSecrets[0].name' | tee -a /dev/stderr)
     [ "${actual}" == "pullSecretValue" ]
 }
 
@@ -40,7 +40,7 @@ load _helpers
         --show-only templates/deployment-brainz.yaml \
         . || echo "---") | tee -a /dev/stderr)
 
-    local actual=$(echo "$object" | yq -r -c '.spec.template.spec.imagePullSecrets[0].name' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 '.spec.template.spec.imagePullSecrets[0].name' | tee -a /dev/stderr)
     [ "${actual}" == "pullSecretValue" ]
 }
 
@@ -54,7 +54,7 @@ load _helpers
         --show-only templates/deployment-ui.yaml \
         . || echo "---") | tee -a /dev/stderr)
 
-    local actual=$(echo "$object" | yq -r -c '.spec.template.spec.imagePullSecrets[0].name' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 '.spec.template.spec.imagePullSecrets[0].name' | tee -a /dev/stderr)
     [ "${actual}" == "pullSecretValue" ]
 }
 

--- a/varnish-controller/test/unit/secret-credentials.bats
+++ b/varnish-controller/test/unit/secret-credentials.bats
@@ -11,16 +11,16 @@ load _helpers
         --namespace default \
         . || echo "---") | tee -a /dev/stderr)
 
-    local actual=$(echo "$object" | yq -r -c '.data."nats-varnish-password"' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 '.data."nats-varnish-password"' | tee -a /dev/stderr)
     [ "${actual}" != "" ]
 
-    local actual=$(echo "$object" | yq -r -c '.data."postgresql-admin-password"' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 '.data."postgresql-admin-password"' | tee -a /dev/stderr)
     [ "${actual}" != "" ]
 
-    local actual=$(echo "$object" | yq -r -c '.data."postgresql-varnish-password"' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 '.data."postgresql-varnish-password"' | tee -a /dev/stderr)
     [ "${actual}" != "" ]
 
-    local actual=$(echo "$object" | yq -r -c '.data."varnish-admin-password"' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 '.data."varnish-admin-password"' | tee -a /dev/stderr)
     [ "${actual}" != "" ]
 }
 
@@ -48,7 +48,7 @@ load _helpers
         --namespace default \
         . || echo "---") | tee -a /dev/stderr)
 
-    local actual=$(echo "$object" | yq -r -c '.data."nats-varnish-password"' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 '.data."nats-varnish-password"' | tee -a /dev/stderr)
     [ "${actual}" == "null" ]
 }
 
@@ -62,10 +62,10 @@ load _helpers
         --namespace default \
         . || echo "---") | tee -a /dev/stderr)
 
-    local actual=$(echo "$object" | yq -r -c '.data."postgresql-admin-password"' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 '.data."postgresql-admin-password"' | tee -a /dev/stderr)
     [ "${actual}" == "null" ]
 
-    local actual=$(echo "$object" | yq -r -c '.data."postgresql-varnish-password"' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 '.data."postgresql-varnish-password"' | tee -a /dev/stderr)
     [ "${actual}" == "null" ]
 }
 
@@ -79,10 +79,10 @@ load _helpers
         --namespace default \
         . || echo "---") | tee -a /dev/stderr)
 
-    local actual=$(echo "$object" | yq -r -c '.data."postgresql-admin-password"' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 '.data."postgresql-admin-password"' | tee -a /dev/stderr)
     [ "${actual}" == "null" ]
 
-    local actual=$(echo "$object" | yq -r -c '.data."postgresql-varnish-password"' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 '.data."postgresql-varnish-password"' | tee -a /dev/stderr)
     [ "${actual}" == "null" ]
 }
 
@@ -96,6 +96,6 @@ load _helpers
         --namespace default \
         . || echo "---") | tee -a /dev/stderr)
 
-    local actual=$(echo "$object" | yq -r -c '.data."varnish-admin-password"' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 '.data."varnish-admin-password"' | tee -a /dev/stderr)
     [ "${actual}" == "null" ]
 }

--- a/varnish-controller/test/unit/service-apigw.bats
+++ b/varnish-controller/test/unit/service-apigw.bats
@@ -11,7 +11,7 @@ load _helpers
         --show-only templates/service-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr)
 
-    local actual=$(echo "$object" | yq -r -c '.metadata.annotations' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 '.metadata.annotations' | tee -a /dev/stderr)
     [ "${actual}" == "null" ]
 }
 
@@ -25,7 +25,7 @@ load _helpers
         --show-only templates/service-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr)
 
-    local actual=$(echo "$object" | yq -r -c '.metadata.annotations' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 '.metadata.annotations' | tee -a /dev/stderr)
     [ "${actual}" == '{"hello":"world"}' ]
 }
 
@@ -43,6 +43,6 @@ release-name: {{ .Release.Name }}
         --show-only templates/service-apigw.yaml \
         . || echo "---") | tee -a /dev/stderr)
 
-    local actual=$(echo "$object" | yq -r -c '.metadata.annotations' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 '.metadata.annotations' | tee -a /dev/stderr)
     [ "${actual}" == '{"release-name":"release-name"}' ]
 }

--- a/varnish-controller/test/unit/service-ui.bats
+++ b/varnish-controller/test/unit/service-ui.bats
@@ -11,7 +11,7 @@ load _helpers
         --show-only templates/service-ui.yaml \
         . || echo "---") | tee -a /dev/stderr)
 
-    local actual=$(echo "$object" | yq -r -c '.metadata.annotations' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 '.metadata.annotations' | tee -a /dev/stderr)
     [ "${actual}" == "null" ]
 }
 
@@ -25,7 +25,7 @@ load _helpers
         --show-only templates/service-ui.yaml \
         . || echo "---") | tee -a /dev/stderr)
 
-    local actual=$(echo "$object" | yq -r -c '.metadata.annotations' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 '.metadata.annotations' | tee -a /dev/stderr)
     [ "${actual}" == '{"hello":"world"}' ]
 }
 
@@ -43,6 +43,6 @@ release-name: {{ .Release.Name }}
         --show-only templates/service-ui.yaml \
         . || echo "---") | tee -a /dev/stderr)
 
-    local actual=$(echo "$object" | yq -r -c '.metadata.annotations' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 '.metadata.annotations' | tee -a /dev/stderr)
     [ "${actual}" == '{"release-name":"release-name"}' ]
 }

--- a/varnish-enterprise/templates/_pod.tpl
+++ b/varnish-enterprise/templates/_pod.tpl
@@ -374,8 +374,6 @@ Composing the $varnishArgs list or arguments
 {{- $malloc := .Values.server.malloc.enabled }}
 {{- if eq .Values.global.edition "enterprise" }}
 {{- $mse4 = .Values.server.mse4.enabled }}
-{{- end }}
-{{- if eq .Values.global.edition "enterprise" }}
   {{- if or (and (eq (kindOf .Values.server.mse.enabled) "string") (eq .Values.server.mse.enabled "-") (not $mse4) (not $malloc) ) (and (eq (kindOf .Values.server.mse.enabled) "bool") .Values.server.mse.enabled) }}
     {{- $mse = true }}
   {{- else }}

--- a/varnish-enterprise/templates/_pod.tpl
+++ b/varnish-enterprise/templates/_pod.tpl
@@ -218,12 +218,10 @@ volumes:
     name: {{ include "varnish-enterprise.fullname" $ }}-vcl-{{ regexReplaceAll "\\W+" $k "-" }}
 {{- end }}
 {{- end }}
-{{- if eq .Values.global.edition "enterprise" }}
-{{- if .Values.cluster.enabled }}
+{{- if and (eq .Values.global.edition "enterprise") .Values.cluster.enabled }}
 - name: {{ $.Release.Name }}-config-vcl-{{ regexReplaceAll "\\W+" $wrappedDefaultVCL "-" }}
   configMap:
     name: {{ include "varnish-enterprise.fullname" $ }}-vcl-{{ regexReplaceAll "\\W+" $wrappedDefaultVCL "-" }}
-{{- end }}
 {{- end }}
 {{- if not (eq (include "varnish-enterprise.cmdfileConfig" .) "") }}
 - name: {{ .Release.Name }}-config-cmdfile
@@ -231,11 +229,9 @@ volumes:
     name: {{ include "varnish-enterprise.fullname" . }}-cmdfile
 {{- end }}
 {{- end }}
-{{- if eq .Values.global.edition "enterprise" }}
-{{- if and .Values.server.agent.enabled (not .Values.server.agent.persistence.enabled) (eq .Values.server.agent.persistence.enableWithVolumeName "") }}
+{{- if and (eq .Values.global.edition "enterprise") .Values.server.agent.enabled (not .Values.server.agent.persistence.enabled) (eq .Values.server.agent.persistence.enableWithVolumeName "") }}
 - name: {{ .Release.Name }}-varnish-controller
   emptyDir: {}
-{{- end }}
 {{- end }}
 {{- if .Values.server.extraVolumes }}
   {{- $tp := kindOf .Values.server.extraVolumes }}
@@ -579,8 +575,7 @@ Composing the $varnishArgs list or arguments
     - name: VARNISH_WORKDIR
       value: "{{ .Values.server.workDir }}"
     {{- end }}
-    {{- if eq .Values.global.edition "enterprise" }}
-    {{- if .Values.cluster.enabled }}
+    {{- if and (eq .Values.global.edition "enterprise") .Values.cluster.enabled }}
     - name: VARNISH_CLUSTER_TOKEN
       valueFrom:
         secretKeyRef:
@@ -590,7 +585,6 @@ Composing the $varnishArgs list or arguments
           name: {{ include "varnish-enterprise.fullname" . }}-cluster-secret
           {{- end }}
           key: token
-    {{- end }}
     {{- end }}
     {{- include "varnish-enterprise.toEnv" (merge (dict "envs" .Values.server.extraEnvs) .) | nindent 4 }}
   {{- if gt (len .Values.server.command) 0 }}
@@ -667,13 +661,11 @@ Composing the $varnishArgs list or arguments
       subPath: {{ $k | quote }}
     {{- end }}
     {{- end }}
-    {{- if eq .Values.global.edition "enterprise" }}
-    {{- if .Values.cluster.enabled }}
+    {{- if and (eq .Values.global.edition "enterprise") .Values.cluster.enabled }}
     {{- $wrappedDefaultVCL := "wrapped-default.vcl" }}
     - name: {{ $.Release.Name }}-config-vcl-{{ regexReplaceAll "\\W+" $wrappedDefaultVCL "-" }}
       mountPath: {{ list (dir $.Values.server.vclConfigPath) $wrappedDefaultVCL | join "/" | quote }}
       subPath: {{ $wrappedDefaultVCL | quote }}
-    {{- end }}
     {{- end }}
     {{- if not (eq (include "varnish-enterprise.cmdfileConfig" .) "") }}
     - name: {{ .Release.Name }}-config-cmdfile

--- a/varnish-enterprise/templates/_pod.tpl
+++ b/varnish-enterprise/templates/_pod.tpl
@@ -374,11 +374,7 @@ Composing the $varnishArgs list or arguments
 {{- $malloc := .Values.server.malloc.enabled }}
 {{- if eq .Values.global.edition "enterprise" }}
 {{- $mse4 = .Values.server.mse4.enabled }}
-  {{- if or (and (eq (kindOf .Values.server.mse.enabled) "string") (eq .Values.server.mse.enabled "-") (not $mse4) (not $malloc) ) (and (eq (kindOf .Values.server.mse.enabled) "bool") .Values.server.mse.enabled) }}
-    {{- $mse = true }}
-  {{- else }}
-    {{- $mse = false }}
-  {{- end }}
+  {{- $mse = or (and (eq (kindOf .Values.server.mse.enabled) "string") (eq .Values.server.mse.enabled "-") (not $mse4) (not $malloc) ) (and (eq (kindOf .Values.server.mse.enabled) "bool") .Values.server.mse.enabled) }}
   {{- if or (and $malloc $mse) (and $malloc $mse4) (and $mse $mse4) }}
     {{- fail "Only one of these storages can be enabled at the same time: 'server.mse.enabled', 'server.mse4.enabled', 'server.malloc.enabled'" }}
   {{- end }}

--- a/varnish-enterprise/templates/_pod.tpl
+++ b/varnish-enterprise/templates/_pod.tpl
@@ -4,8 +4,12 @@ Sets up Pod annotations
 {{- define "varnish-enterprise.podAnnotations" }}
 {{- $section := default "server" .section }}
 {{- $defaultVcl := osBase .Values.server.vclConfigPath }}
-{{- $mseConfig := include "varnish-enterprise.mseConfig" . }}
-{{- $mse4Config := include "varnish-enterprise.mse4Config" . }}
+{{- $mseConfig := "" }}
+{{- $mse4Config := "" }}
+{{- if eq .Values.global.edition "enterprise" }}
+{{- $mseConfig = include "varnish-enterprise.mseConfig" . }}
+{{- $mse4Config = include "varnish-enterprise.mse4Config" . }}
+{{- end }}
 {{- $tlsConfig := include "varnish-enterprise.tlsConfig" . }}
 {{- $vclConfig := include "varnish-enterprise.vclConfig" . }}
 {{- $vclConfigs := omit .Values.server.vclConfigs $defaultVcl }}
@@ -40,11 +44,15 @@ Sets up Pod annotations
 {{- $bundleData := dict
     "routes" .Values.server.vcls.routes
     "includes" .Values.server.vcls.includes
+    "serverHttpPort" .Values.server.http.port
+}}
+{{- if eq .Values.global.edition "enterprise" }}
+{{- $bundleData = merge $bundleData (dict
     "clusterEnabled" .Values.cluster.enabled
     "clusterTrace" .Values.cluster.trace
     "clusterHeadlessServiceName" .Values.cluster.headlessServiceName
-    "serverHttpPort" .Values.server.http.port
-}}
+) }}
+{{- end }}
 {{- $checksum = (merge (dict (print "checksum/" $.Release.Name "-vcl-bundle") (sha256sum (toJson $bundleData))) $checksum) }}
 {{- end }}
 {{- if not (empty $extraManifests) }}
@@ -128,6 +136,12 @@ Declares the Pod's volume mounts.
 {{- define "varnish-enterprise.podVolumes" }}
 {{- $defaultVcl := osBase .Values.server.vclConfigPath }}
 {{- $wrappedDefaultVCL := "wrapped-default.vcl" }}
+{{- $mseConfig := "" }}
+{{- $mse4Config := "" }}
+{{- if eq .Values.global.edition "enterprise" }}
+{{- $mseConfig = include "varnish-enterprise.mseConfig" . }}
+{{- $mse4Config = include "varnish-enterprise.mse4Config" . }}
+{{- end }}
 volumes:
 - name: {{ .Release.Name }}-varnish-vsm
   emptyDir:
@@ -135,17 +149,17 @@ volumes:
 - name: {{ .Release.Name }}-config-shared
   emptyDir:
     medium: "Memory"
-{{- if .Values.server.licenseSecret }}
+{{- if and (eq .Values.global.edition "enterprise") .Values.server.licenseSecret }}
 - name: varnish-license-volume
   secret:
     secretName: {{ .Values.server.licenseSecret }}
 {{- end}}
-{{- if not (eq (include "varnish-enterprise.mseConfig" .) "") }}
+{{- if not (eq $mseConfig "") }}
 - name: {{ .Release.Name }}-config-mse
   configMap:
     name: {{ include "varnish-enterprise.fullname" . }}-mse
 {{- end }}
-{{- if not (eq (include "varnish-enterprise.mse4Config" .) "") }}
+{{- if not (eq $mse4Config "") }}
 - name: {{ .Release.Name }}-config-mse4
   configMap:
     name: {{ include "varnish-enterprise.fullname" . }}-mse4
@@ -204,10 +218,12 @@ volumes:
     name: {{ include "varnish-enterprise.fullname" $ }}-vcl-{{ regexReplaceAll "\\W+" $k "-" }}
 {{- end }}
 {{- end }}
+{{- if eq .Values.global.edition "enterprise" }}
 {{- if .Values.cluster.enabled }}
 - name: {{ $.Release.Name }}-config-vcl-{{ regexReplaceAll "\\W+" $wrappedDefaultVCL "-" }}
   configMap:
     name: {{ include "varnish-enterprise.fullname" $ }}-vcl-{{ regexReplaceAll "\\W+" $wrappedDefaultVCL "-" }}
+{{- end }}
 {{- end }}
 {{- if not (eq (include "varnish-enterprise.cmdfileConfig" .) "") }}
 - name: {{ .Release.Name }}-config-cmdfile
@@ -215,9 +231,11 @@ volumes:
     name: {{ include "varnish-enterprise.fullname" . }}-cmdfile
 {{- end }}
 {{- end }}
+{{- if eq .Values.global.edition "enterprise" }}
 {{- if and .Values.server.agent.enabled (not .Values.server.agent.persistence.enabled) (eq .Values.server.agent.persistence.enableWithVolumeName "") }}
 - name: {{ .Release.Name }}-varnish-controller
   emptyDir: {}
+{{- end }}
 {{- end }}
 {{- if .Values.server.extraVolumes }}
   {{- $tp := kindOf .Values.server.extraVolumes }}
@@ -261,8 +279,12 @@ Declares the probe for Varnish Enterprise pod
 Declares the Varnish Enterprise container
 */}}
 {{- define "varnish-enterprise.serverContainer" -}}
-{{- $mseConfig := include "varnish-enterprise.mseConfig" . }}
-{{- $mse4Config := include "varnish-enterprise.mse4Config" . }}
+{{- $mseConfig := "" }}
+{{- $mse4Config := "" }}
+{{- if eq .Values.global.edition "enterprise" }}
+{{- $mseConfig = include "varnish-enterprise.mseConfig" . }}
+{{- $mse4Config = include "varnish-enterprise.mse4Config" . }}
+{{- end }}
 {{- $cmdfileConfig := include "varnish-enterprise.cmdfileConfig" . }}
 {{- $defaultVcl := osBase .Values.server.vclConfigPath -}}
 {{/*
@@ -273,6 +295,7 @@ Composing the $varnishArgs list or arguments
 {{- if not (empty .Values.server.vcls.routes) }}
   {{- $varnishArgs = concat $varnishArgs (list "-I" "/etc/varnish/vcls/cmds.cli" "-f" "") }}
 {{- else }}
+  {{- if eq .Values.global.edition "enterprise" }}
   {{- if .Values.server.agent.enabled }}
     {{- if not (eq $cmdfileConfig "") }}
       {{ fail "Cannot enable both cmdfile and agent, use either: 'server.cmdfileConfig' or 'server.agent.enabled'" }}
@@ -288,6 +311,12 @@ Composing the $varnishArgs list or arguments
     {{- $varnishArgs = concat $varnishArgs (list "-f" ( list (dir .Values.server.vclConfigPath) $wrappedDefaultVCL | join "/" )) }}
   {{- else }}
     {{- $varnishArgs = concat $varnishArgs (list "-f" ( .Values.server.vclConfigPath )) }}
+  {{- end }}
+  {{- else }}
+  {{- if not (eq $cmdfileConfig "") }}
+    {{- $varnishArgs = concat $varnishArgs (list "-I" .Values.server.cmdfileConfigPath) }}
+  {{- end }}
+  {{- $varnishArgs = concat $varnishArgs (list "-f" ( .Values.server.vclConfigPath )) }}
   {{- end }}
 {{- end -}}
 {{/*
@@ -345,16 +374,24 @@ Composing the $varnishArgs list or arguments
     Stevedores
 */}}
 {{- $mse := false }}
-{{- $mse4 := .Values.server.mse4.enabled }}
+{{- $mse4 := false }}
 {{- $malloc := .Values.server.malloc.enabled }}
-{{- if or (and (eq (kindOf .Values.server.mse.enabled) "string") (eq .Values.server.mse.enabled "-") (not $mse4) (not $malloc) ) (and (eq (kindOf .Values.server.mse.enabled) "bool") .Values.server.mse.enabled) }}
-  {{- $mse = true }}
-{{- else }}
-  {{- $mse = false }}
+{{- if eq .Values.global.edition "enterprise" }}
+{{- $mse4 = .Values.server.mse4.enabled }}
 {{- end }}
-
-{{- if or (and $malloc $mse) (and $malloc $mse4) (and $mse $mse4) }}
-  {{- fail "Only one of these storages can be enabled at the same time: 'server.mse.enabled', 'server.mse4.enabled', 'server.malloc.enabled'" }}
+{{- if eq .Values.global.edition "enterprise" }}
+  {{- if or (and (eq (kindOf .Values.server.mse.enabled) "string") (eq .Values.server.mse.enabled "-") (not $mse4) (not $malloc) ) (and (eq (kindOf .Values.server.mse.enabled) "bool") .Values.server.mse.enabled) }}
+    {{- $mse = true }}
+  {{- else }}
+    {{- $mse = false }}
+  {{- end }}
+  {{- if or (and $malloc $mse) (and $malloc $mse4) (and $mse $mse4) }}
+    {{- fail "Only one of these storages can be enabled at the same time: 'server.mse.enabled', 'server.mse4.enabled', 'server.malloc.enabled'" }}
+  {{- end }}
+{{- else }}
+  {{- if $mse4 }}
+    {{- fail "server.mse4 is not available in community edition, use server.malloc.enabled instead" }}
+  {{- end }}
 {{- end }}
 
 {{- if $mse }}
@@ -385,7 +422,11 @@ Composing the $varnishArgs list or arguments
     {{- $varnishArgs = concat $varnishArgs (list "-s" (printf "Transient=malloc,%s" .Values.server.malloc.transient.size)) }}
   {{- end }}
 {{- else }}
-  {{- fail "Exactly one of MSE, MSE4 or malloc must be enabled: 'server.mse.enabled', 'server.mse4.enabled', 'server.malloc.enabled'" }}
+  {{- if eq .Values.global.edition "enterprise" }}
+    {{- fail "Exactly one of MSE, MSE4 or malloc must be enabled: 'server.mse.enabled', 'server.mse4.enabled', 'server.malloc.enabled'" }}
+  {{- else }}
+    {{- fail "server.malloc.enabled must be set to true in community edition" }}
+  {{- end }}
 {{- end -}}
 {{/*
     TLS
@@ -484,9 +525,8 @@ Composing the $varnishArgs list or arguments
   {{- include "varnish-enterprise.varnishPodProbe" (merge (dict "probeName" "readinessProbe") .) | nindent 2 }}
   {{- include "varnish-enterprise.resources" (merge (dict "section" "server") .) | nindent 2 }}
   env:
-    {{- if and (and (eq (kindOf .Values.server.mse.enabled) "bool") .Values.server.mse.enabled) .Values.server.mse4.enabled }}
-    {{- fail "Only one of MSE or MSE4 can be enabled at the same time: 'server.mse.enabled' or 'server.mse4.enabled'" }}
-    {{- else if or (and (eq (kindOf .Values.server.mse.enabled) "bool") .Values.server.mse.enabled) (and (eq (kindOf .Values.server.mse.enabled) "string") (eq .Values.server.mse.enabled "-") (not .Values.server.mse4.enabled)) }}
+    {{- if eq .Values.global.edition "enterprise" }}
+    {{- if $mse }}
     {{- if and .Values.server.mse.memoryTarget (not (eq .Values.server.mse.memoryTarget "")) }}
     - name: MSE_MEMORY_TARGET
       value: {{ .Values.server.mse.memoryTarget | quote }}
@@ -495,7 +535,7 @@ Composing the $varnishArgs list or arguments
     - name: MSE_CONFIG
       value: /etc/varnish/mse.conf
     {{- end }}
-    {{- else if .Values.server.mse4.enabled }}
+    {{- else if $mse4 }}
     {{- if and .Values.server.mse4.memoryTarget (not (eq .Values.server.mse4.memoryTarget "")) }}
     - name: MSE_MEMORY_TARGET
       value: {{ .Values.server.mse4.memoryTarget | quote }}
@@ -507,7 +547,7 @@ Composing the $varnishArgs list or arguments
     - name: VARNISH_STORAGE_BACKEND
       value: "mse4"
     {{- end }}
-    {{- else }}
+    {{- end }}
     {{- end }}
 
     {{- if .Values.server.tls.enabled }}
@@ -519,7 +559,7 @@ Composing the $varnishArgs list or arguments
       value: "true"
     {{- end }}
     {{- end }}
-    {{- if and .Values.server.agent.enabled (not .Values.server.initAgent.enabled) }}
+    {{- if and (eq .Values.global.edition "enterprise") .Values.server.agent.enabled (not .Values.server.initAgent.enabled) }}
     {{- if and (eq (toString .Values.server.replicas) "1") .Values.server.agent.useReleaseName }}
     - name: VARNISH_CONTROLLER_AGENT_NAME
       value: "{{ .Release.Name }}"
@@ -539,6 +579,7 @@ Composing the $varnishArgs list or arguments
     - name: VARNISH_WORKDIR
       value: "{{ .Values.server.workDir }}"
     {{- end }}
+    {{- if eq .Values.global.edition "enterprise" }}
     {{- if .Values.cluster.enabled }}
     - name: VARNISH_CLUSTER_TOKEN
       valueFrom:
@@ -549,6 +590,7 @@ Composing the $varnishArgs list or arguments
           name: {{ include "varnish-enterprise.fullname" . }}-cluster-secret
           {{- end }}
           key: token
+    {{- end }}
     {{- end }}
     {{- include "varnish-enterprise.toEnv" (merge (dict "envs" .Values.server.extraEnvs) .) | nindent 4 }}
   {{- if gt (len .Values.server.command) 0 }}
@@ -569,12 +611,12 @@ Composing the $varnishArgs list or arguments
       readOnly: true
       subPath: varnish-enterprise.lic
     {{- end}}
-    {{- if not (eq (include "varnish-enterprise.mseConfig" .) "") }}
+    {{- if not (eq $mseConfig "") }}
     - name: {{ .Release.Name }}-config-mse
       mountPath: /etc/varnish/mse.conf
       subPath: mse.conf
     {{- end }}
-    {{- if not (eq (include "varnish-enterprise.mse4Config" .) "") }}
+    {{- if not (eq $mse4Config "") }}
     - name: {{ .Release.Name }}-config-mse4
       mountPath: /etc/varnish/mse4.conf
       subPath: mse4.conf
@@ -625,11 +667,13 @@ Composing the $varnishArgs list or arguments
       subPath: {{ $k | quote }}
     {{- end }}
     {{- end }}
+    {{- if eq .Values.global.edition "enterprise" }}
     {{- if .Values.cluster.enabled }}
     {{- $wrappedDefaultVCL := "wrapped-default.vcl" }}
     - name: {{ $.Release.Name }}-config-vcl-{{ regexReplaceAll "\\W+" $wrappedDefaultVCL "-" }}
       mountPath: {{ list (dir $.Values.server.vclConfigPath) $wrappedDefaultVCL | join "/" | quote }}
       subPath: {{ $wrappedDefaultVCL | quote }}
+    {{- end }}
     {{- end }}
     {{- if not (eq (include "varnish-enterprise.cmdfileConfig" .) "") }}
     - name: {{ .Release.Name }}-config-cmdfile
@@ -637,6 +681,7 @@ Composing the $varnishArgs list or arguments
       subPath: cmds.cli
     {{- end }}
     {{- end }}
+    {{- if eq .Values.global.edition "enterprise" }}
     {{- if and (eq .Values.server.kind "StatefulSet") (and (or (and (eq (kindOf .Values.server.mse.enabled) "bool") .Values.server.mse.enabled) (and (eq (kindOf .Values.server.mse.enabled) "string") (eq .Values.server.mse.enabled "-") (not .Values.server.mse4.enabled))) .Values.server.mse.persistence.enabled) }}
     - name: {{ .Release.Name }}-mse
       mountPath: {{ .Values.server.mse.persistence.mountPath }}
@@ -652,6 +697,7 @@ Composing the $varnishArgs list or arguments
     {{- else }}
     - name: {{ .Release.Name }}-varnish-controller
       mountPath: /var/lib/varnish-controller
+    {{- end }}
     {{- end }}
     {{- end }}
     {{- if .Values.server.extraVolumeMounts }}
@@ -769,7 +815,7 @@ Declares the Varnish NCSA container
 Declares the Varnish Otel container
 */}}
 {{- define "varnish-enterprise.otelContainer" -}}
-{{- if .Values.server.otel.enabled }}
+{{- if and (eq .Values.global.edition "enterprise") .Values.server.otel.enabled }}
 - name: {{ .Chart.Name }}-otel
   {{- include "varnish-enterprise.securityContext" (merge (dict "section" "server.otel") .) | nindent 2 }}
   {{- include "varnish-enterprise.image" (merge (dict "base" .Values.server.image "image" .Values.server.otel.image) .) | nindent 2 }}
@@ -800,7 +846,7 @@ Declares the Varnish Otel container
 Declares the Varnish Controller Agent container
 */}}
 {{- define "varnish-enterprise.agentContainer" -}}
-{{- if .Values.server.agent.enabled }}
+{{- if and (eq .Values.global.edition "enterprise") .Values.server.agent.enabled }}
 - name: {{ .Chart.Name }}-agent
   {{- include "varnish-enterprise.securityContext" (merge (dict "section" "server.agent") .) | nindent 2 }}
   {{- include "varnish-enterprise.image" (merge (dict "image" .Values.server.agent.image) .) | nindent 2 }}
@@ -924,7 +970,7 @@ Declares the Varnish Controller Agent container
 Declares the Varnish Controller VCLI container for agent auto-removal
 */}}
 {{- define "varnish-enterprise.vcliContainer" -}}
-{{- if and .Values.server.agent.enabled (eq .Values.server.agent.autoRemove.method "vcli") }}
+{{- if and (eq .Values.global.edition "enterprise") .Values.server.agent.enabled (eq .Values.server.agent.autoRemove.method "vcli") }}
 - name: {{ .Chart.Name }}-vcli
   {{- include "varnish-enterprise.securityContext" (merge (dict "section" "server.agent.autoRemove.vcli") .) | nindent 2 }}
   {{- include "varnish-enterprise.image" (merge (dict "image" .Values.server.agent.autoRemove.vcli.image) .) | nindent 2 }}
@@ -1037,9 +1083,10 @@ Declares the Varnish extra container
 Declares the Varnish init containers
 */}}
 {{- define "varnish-enterprise.initContainers" -}}
-{{- if or (and .Values.server.agent.enabled .Values.server.initAgent.enabled) .Values.server.extraInitContainers .Values.server.mse.persistence.enabled .Values.server.mse4.persistence.enabled}}
+{{- $enterpriseInits := and (eq .Values.global.edition "enterprise") (or (and .Values.server.agent.enabled .Values.server.initAgent.enabled) .Values.server.mse.persistence.enabled .Values.server.mse4.persistence.enabled) }}
+{{- if or $enterpriseInits .Values.server.extraInitContainers }}
 initContainers:
-{{- if .Values.server.mse.persistence.enabled }}
+{{- if and (eq .Values.global.edition "enterprise") .Values.server.mse.persistence.enabled }}
   - name: mse-config
     {{- include "varnish-enterprise.image" (merge (dict "image" .Values.server.image) .) | nindent 4 }}
     command:
@@ -1054,7 +1101,7 @@ initContainers:
        mountPath: /etc/varnish/mse.conf
        subPath: mse.conf
 {{- end }}
-{{- if .Values.server.mse4.persistence.enabled }}
+{{- if and (eq .Values.global.edition "enterprise") .Values.server.mse4.persistence.enabled }}
   - name: mse4-config
     {{- include "varnish-enterprise.image" (merge (dict "image" .Values.server.image) .) | nindent 4 }}
     command:
@@ -1069,7 +1116,7 @@ initContainers:
        mountPath: /etc/varnish/mse4.conf
        subPath: mse4.conf
 {{- end }}
-{{- if and .Values.server.agent.enabled .Values.server.initAgent.enabled }}
+{{- if and (eq .Values.global.edition "enterprise") .Values.server.agent.enabled .Values.server.initAgent.enabled }}
   - name: init-agent
     image: {{ .Values.global.initContainer.image | default "busybox"}}:{{ .Values.global.initContainer.tag | default "1.36"}}
     command:

--- a/varnish-enterprise/templates/_pod.tpl
+++ b/varnish-enterprise/templates/_pod.tpl
@@ -378,10 +378,6 @@ Composing the $varnishArgs list or arguments
   {{- if or (and $malloc $mse) (and $malloc $mse4) (and $mse $mse4) }}
     {{- fail "Only one of these storages can be enabled at the same time: 'server.mse.enabled', 'server.mse4.enabled', 'server.malloc.enabled'" }}
   {{- end }}
-{{- else }}
-  {{- if $mse4 }}
-    {{- fail "server.mse4 is not available in community edition, use server.malloc.enabled instead" }}
-  {{- end }}
 {{- end }}
 
 {{- if $mse }}

--- a/varnish-enterprise/templates/_pod.tpl
+++ b/varnish-enterprise/templates/_pod.tpl
@@ -342,11 +342,22 @@ Composing the $varnishArgs list or arguments
     {{- $varnishArgs = concat $varnishArgs (list "-S" "/etc/varnish/secret" ) }}
 {{- end -}}
 {{/*
-    MSE
+    Stevedores
 */}}
-{{- if and (and (eq (kindOf .Values.server.mse.enabled) "bool") .Values.server.mse.enabled) .Values.server.mse4.enabled }}
-  {{- fail "Only one of MSE or MSE4 can be enabled at the same time: 'server.mse.enabled' or 'server.mse4.enabled'" }}
-{{- else if or (and (eq (kindOf .Values.server.mse.enabled) "bool") .Values.server.mse.enabled) (and (eq (kindOf .Values.server.mse.enabled) "string") (eq .Values.server.mse.enabled "-") (not .Values.server.mse4.enabled)) }}
+{{- $mse := false }}
+{{- $mse4 := .Values.server.mse4.enabled }}
+{{- $malloc := .Values.server.malloc.enabled }}
+{{- if or (and (eq (kindOf .Values.server.mse.enabled) "string") (eq .Values.server.mse.enabled "-") (not $mse4) (not $malloc) ) (and (eq (kindOf .Values.server.mse.enabled) "bool") .Values.server.mse.enabled) }}
+  {{- $mse = true }}
+{{- else }}
+  {{- $mse = false }}
+{{- end }}
+
+{{- if or (and $malloc $mse) (and $malloc $mse4) (and $mse $mse4) }}
+  {{- fail "Only one of these storages can be enabled at the same time: 'server.mse.enabled', 'server.mse4.enabled', 'server.malloc.enabled'" }}
+{{- end }}
+
+{{- if $mse }}
   {{- if and .Values.server.mse.memoryTarget (not (eq .Values.server.mse.memoryTarget "")) }}
     {{- $varnishArgs = concat $varnishArgs (list "-p" (print "memory_target=" (toString .Values.server.mse.memoryTarget)))}}
   {{- end }}
@@ -355,7 +366,7 @@ Composing the $varnishArgs list or arguments
   {{- else }}
     {{- $varnishArgs = concat $varnishArgs (list "-s" "mse") }}
   {{- end }}
-{{- else if .Values.server.mse4.enabled }}
+{{- else if $mse4 }}
   {{- if and .Values.server.mse4.memoryTarget (not (eq .Values.server.mse4.memoryTarget "")) }}
     {{- $varnishArgs = concat $varnishArgs (list "-p" (print "memory_target=" (toString .Values.server.mse4.memoryTarget))) }}
   {{- end }}
@@ -364,8 +375,17 @@ Composing the $varnishArgs list or arguments
   {{- else }}
     {{- $varnishArgs = concat $varnishArgs (list "-s" "mse4") }}
   {{- end }}
+{{- else if $malloc }}
+  {{- if (eq (kindOf .Values.server.malloc.size) ("string")) }}
+    {{- $varnishArgs = concat $varnishArgs (list "-s" (printf "malloc,%s" .Values.server.malloc.size ) ) }}
+  {{- else }}
+    {{- $varnishArgs = concat $varnishArgs (list "-s" "malloc") }}
+  {{- end -}}
+  {{- if (eq (kindOf .Values.server.malloc.transient.size) ("string")) }}
+    {{- $varnishArgs = concat $varnishArgs (list "-s" (printf "Transient=malloc,%s" .Values.server.malloc.transient.size)) }}
+  {{- end }}
 {{- else }}
-{{- fail "Either MSE or MSE4 must be enabled: 'server.mse.enabled' or 'server.mse4.enabled'" }}
+  {{- fail "Exactly one of MSE, MSE4 or malloc must be enabled: 'server.mse.enabled', 'server.mse4.enabled', 'server.malloc.enabled'" }}
 {{- end -}}
 {{/*
     TLS
@@ -488,7 +508,6 @@ Composing the $varnishArgs list or arguments
       value: "mse4"
     {{- end }}
     {{- else }}
-    {{- fail "Either MSE or MSE4 must be enabled: 'server.mse.enabled' or 'server.mse4.enabled'" }}
     {{- end }}
 
     {{- if .Values.server.tls.enabled }}

--- a/varnish-enterprise/templates/configmap-mse.yaml
+++ b/varnish-enterprise/templates/configmap-mse.yaml
@@ -1,4 +1,7 @@
-{{- $mseConfig := include "varnish-enterprise.mseConfig" . }}
+{{- $mseConfig := "" }}
+{{- if eq .Values.global.edition "enterprise" }}
+{{- $mseConfig = include "varnish-enterprise.mseConfig" . }}
+{{- end }}
 {{- if not (eq $mseConfig "") }}
 apiVersion: v1
 kind: ConfigMap

--- a/varnish-enterprise/templates/configmap-mse4.yaml
+++ b/varnish-enterprise/templates/configmap-mse4.yaml
@@ -1,4 +1,7 @@
-{{- $mse4Config := include "varnish-enterprise.mse4Config" . }}
+{{- $mse4Config := "" }}
+{{- if eq .Values.global.edition "enterprise" }}
+{{- $mse4Config = include "varnish-enterprise.mse4Config" . }}
+{{- end }}
 {{- if not (eq $mse4Config "") }}
 apiVersion: v1
 kind: ConfigMap

--- a/varnish-enterprise/templates/configmap-vcl.yaml
+++ b/varnish-enterprise/templates/configmap-vcl.yaml
@@ -28,7 +28,7 @@ data:
 {{- end }}
 {{- end }}
 
-{{- if .Values.cluster.enabled }}
+{{- if and (eq .Values.global.edition "enterprise") .Values.cluster.enabled }}
 {{- if not .Values.server.http.enabled }}
 {{- fail "'server.http.enabled must be true for clustering to work" }}
 {{- end }}
@@ -78,7 +78,7 @@ metadata:
 data:
   router.vcl: |
     vcl 4.1;
-    {{- if .Values.cluster.enabled }}
+    {{- if and (eq .Values.global.edition "enterprise") .Values.cluster.enabled }}
 
     import activedns;
 
@@ -86,7 +86,7 @@ data:
     {{- end }}
 
     backend default none;
-    {{- if .Values.cluster.enabled }}
+    {{- if and (eq .Values.global.edition "enterprise") .Values.cluster.enabled }}
 
     sub vcl_init {
       {{- if .Values.cluster.trace }}

--- a/varnish-enterprise/templates/daemonset.yaml
+++ b/varnish-enterprise/templates/daemonset.yaml
@@ -2,6 +2,7 @@
 {{- if .Values.server.strategy }}
 {{- fail "'server.strategy' cannot be enabled when 'server.kind' is 'DaemonSet'" }}
 {{- end }}
+{{- if eq .Values.global.edition "enterprise" }}
 {{- if .Values.server.mse.persistence.enabled }}
 {{- fail "'server.mse.persistence.enabled' cannot be enabled when 'server.kind' is 'DaemonSet'" }}
 {{- end }}
@@ -10,6 +11,7 @@
 {{- end }}
 {{- if .Values.server.agent.persistence.enabled }}
 {{- fail "'server.agent.persistence.enabled' cannot be enabled when 'server.kind' is 'DaemonSet'" }}
+{{- end }}
 {{- end }}
 {{- if not (empty .Values.server.extraVolumeClaimTemplates) }}
 {{- fail "'server.extraVolumeClaimTemplates' cannot be enabled when 'server.kind' is 'DaemonSet'" }}

--- a/varnish-enterprise/templates/deployment.yaml
+++ b/varnish-enterprise/templates/deployment.yaml
@@ -2,6 +2,7 @@
 {{- if .Values.server.updateStrategy }}
 {{- fail "'server.updateStrategy' cannot be enabled when 'server.kind' is 'Deployment'" }}
 {{- end }}
+{{- if eq .Values.global.edition "enterprise" }}
 {{- if .Values.server.mse.persistence.enabled }}
 {{- fail "'server.mse.persistence.enabled' cannot be enabled when 'server.kind' is 'Deployment'" }}
 {{- end }}
@@ -10,6 +11,7 @@
 {{- end }}
 {{- if .Values.server.agent.persistence.enabled }}
 {{- fail "'server.agent.persistence.enabled' cannot be enabled when 'server.kind' is 'Deployment'" }}
+{{- end }}
 {{- end }}
 {{- if not (empty .Values.server.extraVolumeClaimTemplates) }}
 {{- fail "'server.extraVolumeClaimTemplates' cannot be enabled when 'server.kind' is 'Deployment'" }}

--- a/varnish-enterprise/templates/secret.yaml
+++ b/varnish-enterprise/templates/secret.yaml
@@ -10,7 +10,7 @@ metadata:
 data:
   secret: {{ $secretConfig | trim | b64enc }}
 {{- end }}
-{{- if and .Values.cluster.enabled (not .Values.cluster.secretName) }}
+{{- if and (eq .Values.global.edition "enterprise") .Values.cluster.enabled (not .Values.cluster.secretName) }}
 ---
 apiVersion: v1
 kind: Secret

--- a/varnish-enterprise/templates/service.yaml
+++ b/varnish-enterprise/templates/service.yaml
@@ -79,7 +79,7 @@ spec:
   selector:
     {{- include "varnish-enterprise.selectorLabels" . | nindent 4 }}
 {{- end }}
-{{- if and .Values.cluster.enabled (not .Values.cluster.headlessServiceName) }}
+{{- if and (eq .Values.global.edition "enterprise") .Values.cluster.enabled (not .Values.cluster.headlessServiceName) }}
 ---
 {{- if not .Values.server.http.enabled }}
 {{- fail "'server.http.enabled must be true for clustering to work" }}

--- a/varnish-enterprise/test/unit/cluster.bats
+++ b/varnish-enterprise/test/unit/cluster.bats
@@ -39,7 +39,7 @@ load _helpers
         --namespace default \
         --show-only templates/deployment.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -cr '.spec.template.spec.containers[] |
+        yq -o=json -I=0 -r '.spec.template.spec.containers[] |
                 select(.name == "varnish-enterprise").env[] |
                 select(.name == "VARNISH_CLUSTER_TOKEN")' | tee -a /dev/stderr)
     [ "${actual}" = "" ]
@@ -53,7 +53,7 @@ load _helpers
         --namespace default \
         --show-only templates/deployment.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -cr '.spec.template.spec.containers[] |
+        yq -o=json -I=0 -r '.spec.template.spec.containers[] |
                 select(.name == "varnish-enterprise").env[] |
                 select(.name == "VARNISH_CLUSTER_TOKEN")' | tee -a /dev/stderr)
     [ "${actual}" = '{"name":"VARNISH_CLUSTER_TOKEN","valueFrom":{"secretKeyRef":{"name":"release-name-varnish-enterprise-cluster-secret","key":"token"}}}' ]
@@ -66,7 +66,7 @@ load _helpers
         --namespace default \
         --show-only templates/configmap-vcl.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -cr '.data["wrapped-default.vcl"]' | tee -a /dev/stderr)
+        yq -o=json -I=0 -r '.data["wrapped-default.vcl"]' | tee -a /dev/stderr)
     echo "${actual}" | grep 'include "cluster.vcl";'
     echo "${actual}" | grep 'include "/etc/varnish/default.vcl";'
 }
@@ -78,7 +78,7 @@ load _helpers
         --namespace default \
         --show-only templates/service.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -cr 'select(.metadata.name == "release-name-varnish-enterprise-peers").spec.ports' | tee -a /dev/stderr)
+        yq -o=json -I=0 -r 'select(.metadata.name == "release-name-varnish-enterprise-peers").spec.ports' | tee -a /dev/stderr)
     [ "${actual}" = '[{"name":"http","port":6081,"targetPort":6081}]' ]
 }
 
@@ -89,7 +89,7 @@ load _helpers
         --namespace default \
         --show-only templates/secret.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -cr '.data.token' | tee -a /dev/stderr)
+        yq -o=json -I=0 -r '.data.token' | tee -a /dev/stderr)
     [ "${actual}" != 'null' ]
 }
 
@@ -101,7 +101,7 @@ load _helpers
         --namespace default \
         --show-only templates/configmap-vcl.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -cr '.data["wrapped-default.vcl"]' | tee -a /dev/stderr)
+        yq -o=json -I=0 -r '.data["wrapped-default.vcl"]' | tee -a /dev/stderr)
     echo "${actual}" | grep '"release-name-varnish-enterprise-peers:9999"'
 }
 
@@ -113,7 +113,7 @@ load _helpers
         --namespace default \
         --show-only templates/configmap-vcl.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -cr '.data["wrapped-default.vcl"]' | tee -a /dev/stderr)
+        yq -o=json -I=0 -r '.data["wrapped-default.vcl"]' | tee -a /dev/stderr)
     echo "${actual}" | grep 'include "/etc/varnish/non-default.vcl";'
 }
 
@@ -137,7 +137,7 @@ load _helpers
         --namespace default \
         --show-only templates/configmap-vcl.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -cr '.data["wrapped-default.vcl"]' | tee -a /dev/stderr)
+        yq -o=json -I=0 -r '.data["wrapped-default.vcl"]' | tee -a /dev/stderr)
     echo "${actual}" | grep '"foo-service:6081"'
 
 }
@@ -161,7 +161,7 @@ load _helpers
         --namespace default \
         --show-only templates/deployment.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -cr '.spec.template.spec.containers[] |
+        yq -o=json -I=0 -r '.spec.template.spec.containers[] |
                 select(.name == "varnish-enterprise").env[] |
                 select(.name == "VARNISH_CLUSTER_TOKEN")' | tee -a /dev/stderr)
     [ "${actual}" = '{"name":"VARNISH_CLUSTER_TOKEN","valueFrom":{"secretKeyRef":{"name":"foo-secret","key":"token"}}}' ]

--- a/varnish-enterprise/test/unit/daemonset.bats
+++ b/varnish-enterprise/test/unit/daemonset.bats
@@ -49,7 +49,7 @@ load _helpers
         --namespace default \
         --show-only templates/daemonset.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.updateStrategy' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.updateStrategy' | tee -a /dev/stderr)
 
     [ "${actual}" == "null" ]
 }
@@ -64,7 +64,7 @@ load _helpers
         --namespace default \
         --show-only templates/daemonset.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.updateStrategy' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.updateStrategy' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}' ]
 }
@@ -84,7 +84,7 @@ rollingUpdate:
         --namespace default \
         --show-only templates/daemonset.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.updateStrategy' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.updateStrategy' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"type":"RollingUpdate","rollingUpdate":{"maxUnavailable":1}}' ]
 }
@@ -132,7 +132,7 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .volumeMounts[]? | select(.name == "my-varnish-controller-volume")' |
             tee -a /dev/stderr)

--- a/varnish-enterprise/test/unit/deployment.bats
+++ b/varnish-enterprise/test/unit/deployment.bats
@@ -32,7 +32,7 @@ load _helpers
         --namespace default \
         --show-only templates/deployment.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.strategy' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.strategy' | tee -a /dev/stderr)
 
     [ "${actual}" == "null" ]
 }
@@ -47,7 +47,7 @@ load _helpers
         --namespace default \
         --show-only templates/deployment.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.strategy' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.strategy' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}' ]
 }
@@ -67,7 +67,7 @@ rollingUpdate:
         --namespace default \
         --show-only templates/deployment.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.strategy' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.strategy' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"type":"RollingUpdate","rollingUpdate":{"maxUnavailable":1}}' ]
 }
@@ -112,7 +112,7 @@ rollingUpdate:
         --namespace default \
         --show-only templates/deployment.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.initContainers[]? | select(.name == "init-agent") | .image' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.initContainers[]? | select(.name == "init-agent") | .image' | tee -a /dev/stderr)
 
     [ "${actual}" == "ubuntu:24.04" ]
 }
@@ -147,7 +147,7 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .volumeMounts[]? | select(.name == "my-varnish-controller-volume")' |
             tee -a /dev/stderr)

--- a/varnish-enterprise/test/unit/extra.bats
+++ b/varnish-enterprise/test/unit/extra.bats
@@ -51,13 +51,13 @@ EOF
         . || echo "---") |
         tee -a /dev/stderr)
 
-    local actual=$(echo "$object" | yq -c | wc -l | xargs | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -o=json -I=0 | wc -l | xargs | tee -a /dev/stderr)
     [ "${actual}" == "2" ]
 
-    local actual=$(echo "$object" | yq -r -c 'select(.metadata.name == "release-name-clusterrole")' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 'select(.metadata.name == "release-name-clusterrole")' | tee -a /dev/stderr)
     [ "${actual}" == '{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"ClusterRole","metadata":{"name":"release-name-clusterrole"},"rules":[{"apiGroups":[""],"resources":["endpoints"],"verbs":["get","list","watch"]}]}' ]
 
-    local actual=$(echo "$object" | yq -r -c 'select(.metadata.name == "release-name-clusterrolebinding")' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 'select(.metadata.name == "release-name-clusterrolebinding")' | tee -a /dev/stderr)
     [ "${actual}" == '{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"ClusterRoleBinding","metadata":{"name":"release-name-clusterrolebinding"},"roleRef":{"kind":"ClusterRole","name":"release-name-clusterrole","apiGroup":"rbac.authorization.k8s.io"},"subjects":[{"kind":"ServiceAccount","name":"release-name","namespace":"default"}]}' ]
 }
 
@@ -100,12 +100,12 @@ EOF
         . || echo "---") |
         tee -a /dev/stderr)
 
-    local actual=$(echo "$object" | yq -c | wc -l | xargs | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -o=json -I=0 | wc -l | xargs | tee -a /dev/stderr)
     [ "${actual}" == "2" ]
 
-    local actual=$(echo "$object" | yq -r -c 'select(.metadata.name == "varnish-enterprise-clusterrole")' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 'select(.metadata.name == "varnish-enterprise-clusterrole")' | tee -a /dev/stderr)
     [ "${actual}" == '{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"ClusterRole","metadata":{"name":"varnish-enterprise-clusterrole"},"rules":[{"apiGroups":[""],"resources":["endpoints"],"verbs":["get","list","watch"]}]}' ]
 
-    local actual=$(echo "$object" | yq -r -c 'select(.metadata.name == "varnish-enterprise-clusterrolebinding")' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 'select(.metadata.name == "varnish-enterprise-clusterrolebinding")' | tee -a /dev/stderr)
     [ "${actual}" == '{"apiVersion":"rbac.authorization.k8s.io/v1","kind":"ClusterRoleBinding","metadata":{"name":"varnish-enterprise-clusterrolebinding"},"roleRef":{"apiGroup":"rbac.authorization.k8s.io","kind":"ClusterRole","name":"varnish-enterprise-clusterrole"},"subjects":[{"kind":"ServiceAccount","name":"varnish-enterprise","namespace":"default"}]}' ]
 }

--- a/varnish-enterprise/test/unit/hpa.bats
+++ b/varnish-enterprise/test/unit/hpa.bats
@@ -24,24 +24,24 @@ load _helpers
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c 'length > 0' |
+        yq -r -o=json -I=0 'length > 0' |
         tee -a /dev/stderr)
     [ "${actual}" == "true" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.minReplicas' |
+        yq -r -o=json -I=0 '.spec.minReplicas' |
         tee -a /dev/stderr)
     [ "${actual}" == "2" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.maxReplicas' |
+        yq -r -o=json -I=0 '.spec.maxReplicas' |
         tee -a /dev/stderr)
     [ "${actual}" == "10" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.maxReplicas | type' |
+        yq -r -o=json -I=0 '.spec.maxReplicas | type' |
         tee -a /dev/stderr)
-    [ "${actual}" == "number" ]
+    [ "${actual}" == "!!int" ]
 }
 
 @test "HorizontalPodAutoscaler: can be enabled with minReplicas and maxReplicas" {
@@ -56,24 +56,24 @@ load _helpers
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c 'length > 0' |
+        yq -r -o=json -I=0 'length > 0' |
         tee -a /dev/stderr)
     [ "${actual}" == "true" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.minReplicas' |
+        yq -r -o=json -I=0 '.spec.minReplicas' |
         tee -a /dev/stderr)
     [ "${actual}" == "2" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.maxReplicas' |
+        yq -r -o=json -I=0 '.spec.maxReplicas' |
         tee -a /dev/stderr)
     [ "${actual}" == "10" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.maxReplicas | type' |
+        yq -r -o=json -I=0 '.spec.maxReplicas | type' |
         tee -a /dev/stderr)
-    [ "${actual}" == "number" ]
+    [ "${actual}" == "!!int" ]
 }
 
 @test "HorizontalPodAutoscaler/behavior: can be set" {
@@ -89,7 +89,7 @@ load _helpers
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.behavior' |
+        yq -r -o=json -I=0 '.spec.behavior' |
         tee -a /dev/stderr)
     [ "${actual}" == '{"scaleDown":{"policies":[{"periodSeconds":60,"type":"Pods","value":4}]}}' ]
 }
@@ -112,7 +112,7 @@ scaleDown:
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.behavior' |
+        yq -r -o=json -I=0 '.spec.behavior' |
         tee -a /dev/stderr)
     [ "${actual}" == '{"scaleDown":{"policies":[{"type":"Pods","value":4,"periodSeconds":60}]}}' ]
 }
@@ -131,7 +131,7 @@ scaleDown:
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.metrics' |
+        yq -r -o=json -I=0 '.spec.metrics' |
         tee -a /dev/stderr)
     [ "${actual}" == '[{"resource":{"name":"cpu","target":{"averageUtilization":50,"type":"Utilization"}},"type":"Resource"}]' ]
 }
@@ -155,7 +155,7 @@ scaleDown:
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.metrics' |
+        yq -r -o=json -I=0 '.spec.metrics' |
         tee -a /dev/stderr)
     [ "${actual}" == '[{"type":"Resources","resource":{"name":"cpu","target":{"type":"Utilization","averageUtilization":50}}}]' ]
 }

--- a/varnish-enterprise/test/unit/pdb.bats
+++ b/varnish-enterprise/test/unit/pdb.bats
@@ -23,22 +23,22 @@ load _helpers
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c 'length > 0' |
+        yq -r -o=json -I=0 'length > 0' |
         tee -a /dev/stderr)
     [ "${actual}" == "true" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.minAvailable' |
+        yq -r -o=json -I=0 '.spec.minAvailable' |
         tee -a /dev/stderr)
     [ "${actual}" == "30%" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.minAvailable | type' |
+        yq -r -o=json -I=0 '.spec.minAvailable | type' |
         tee -a /dev/stderr)
-    [ "${actual}" == "string" ]
+    [ "${actual}" == "!!str" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.maxUnavailable' |
+        yq -r -o=json -I=0 '.spec.maxUnavailable' |
         tee -a /dev/stderr)
     [ "${actual}" == "null" ]
 }
@@ -55,22 +55,22 @@ load _helpers
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c 'length > 0' |
+        yq -r -o=json -I=0 'length > 0' |
         tee -a /dev/stderr)
     [ "${actual}" == "true" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.minAvailable' |
+        yq -r -o=json -I=0 '.spec.minAvailable' |
         tee -a /dev/stderr)
     [ "${actual}" == "5" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.minAvailable | type' |
+        yq -r -o=json -I=0 '.spec.minAvailable | type' |
         tee -a /dev/stderr)
-    [ "${actual}" == "number" ]
+    [ "${actual}" == "!!int" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.maxUnavailable' |
+        yq -r -o=json -I=0 '.spec.maxUnavailable' |
         tee -a /dev/stderr)
     [ "${actual}" == "null" ]
 }
@@ -86,24 +86,24 @@ load _helpers
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c 'length > 0' |
+        yq -r -o=json -I=0 'length > 0' |
         tee -a /dev/stderr)
     [ "${actual}" == "true" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.minAvailable' |
+        yq -r -o=json -I=0 '.spec.minAvailable' |
         tee -a /dev/stderr)
     [ "${actual}" == "null" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.maxUnavailable' |
+        yq -r -o=json -I=0 '.spec.maxUnavailable' |
         tee -a /dev/stderr)
     [ "${actual}" == "30%" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.maxUnavailable | type' |
+        yq -r -o=json -I=0 '.spec.maxUnavailable | type' |
         tee -a /dev/stderr)
-    [ "${actual}" == "string" ]
+    [ "${actual}" == "!!str" ]
 }
 
 # Kubernetes only accept maxUnavailable as a string only for percent.
@@ -118,24 +118,24 @@ load _helpers
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c 'length > 0' |
+        yq -r -o=json -I=0 'length > 0' |
         tee -a /dev/stderr)
     [ "${actual}" == "true" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.minAvailable' |
+        yq -r -o=json -I=0 '.spec.minAvailable' |
         tee -a /dev/stderr)
     [ "${actual}" == "null" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.maxUnavailable' |
+        yq -r -o=json -I=0 '.spec.maxUnavailable' |
         tee -a /dev/stderr)
     [ "${actual}" == "5" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.maxUnavailable | type' |
+        yq -r -o=json -I=0 '.spec.maxUnavailable | type' |
         tee -a /dev/stderr)
-    [ "${actual}" == "number" ]
+    [ "${actual}" == "!!int" ]
 }
 
 @test "PodDisruptionBudget: cannot be enabled without minAvailable or maxUnavailable" {

--- a/varnish-enterprise/test/unit/service.bats
+++ b/varnish-enterprise/test/unit/service.bats
@@ -27,7 +27,7 @@ load _helpers
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.externalTrafficPolicy' |
+        yq -r -o=json -I=0 '.spec.externalTrafficPolicy' |
         tee -a /dev/stderr)
 
     [ "${actual}" == "Cluster" ]
@@ -44,7 +44,7 @@ load _helpers
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.externalTrafficPolicy' |
+        yq -r -o=json -I=0 '.spec.externalTrafficPolicy' |
         tee -a /dev/stderr)
 
     [ "${actual}" == "Local" ]

--- a/varnish-enterprise/test/unit/statefulset.bats
+++ b/varnish-enterprise/test/unit/statefulset.bats
@@ -47,7 +47,7 @@ load _helpers
         --namespace default \
         --show-only templates/statefulset.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.updateStrategy' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.updateStrategy' | tee -a /dev/stderr)
 
     [ "${actual}" == "null" ]
 }
@@ -62,7 +62,7 @@ load _helpers
         --namespace default \
         --show-only templates/statefulset.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.updateStrategy' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.updateStrategy' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}' ]
 }
@@ -82,7 +82,7 @@ rollingUpdate:
         --namespace default \
         --show-only templates/statefulset.yaml \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.updateStrategy' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.updateStrategy' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"type":"RollingUpdate","rollingUpdate":{"maxUnavailable":1}}' ]
 }
@@ -98,17 +98,17 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.volumeClaimTemplates[]? | select(.metadata.name == "release-name-mse")' |
+        yq -r -o=json -I=0 '.spec.volumeClaimTemplates[]? | select(.metadata.name == "release-name-mse")' |
             tee -a /dev/stderr)
     [ "${actual}" = "" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-mse")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-mse")' |
             tee -a /dev/stderr)
     [ "${actual}" = "" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .volumeMounts[] | select(.name == "release-name-mse")' |
             tee -a /dev/stderr)
@@ -127,19 +127,19 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.volumeClaimTemplates[]? | select(.metadata.name == "release-name-mse") |
             .spec' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"10Gi"}}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-mse")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-mse")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-mse","configMap":{"name":"release-name-varnish-enterprise-mse"}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .volumeMounts[] | select(.name == "release-name-mse")' |
             tee -a /dev/stderr)
@@ -157,7 +157,7 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.initContainers[]? | select(.name == "mse-config") |
               .name'  | tee -a /dev/stderr)
     [ "${actual}" = '' ]
@@ -176,7 +176,7 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.initContainers[]? | select(.name == "mse-config") |
               .name'  | tee -a /dev/stderr)
     [ "${actual}" = 'mse-config' ]
@@ -196,7 +196,7 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.volumeClaimTemplates[]? | select(.metadata.name == "release-name-mse") |
             .spec' |
             tee -a /dev/stderr)
@@ -207,7 +207,7 @@ rollingUpdate:
             tee -a /dev/stderr)
 
     local actual=$(echo "$containerObject" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-mse")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-mse")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-mse","mountPath":"/data1/mse"}' ]
 }
@@ -224,17 +224,17 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.volumeClaimTemplates[]? | select(.metadata.name == "release-name-mse4")' |
+        yq -r -o=json -I=0 '.spec.volumeClaimTemplates[]? | select(.metadata.name == "release-name-mse4")' |
             tee -a /dev/stderr)
     [ "${actual}" = "" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-mse4")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-mse4")' |
             tee -a /dev/stderr)
     [ "${actual}" = "" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .volumeMounts[] | select(.name == "release-name-mse4")' |
             tee -a /dev/stderr)
@@ -254,19 +254,19 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.volumeClaimTemplates[]? | select(.metadata.name == "release-name-mse4") |
             .spec' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"10Gi"}}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-mse4")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-mse4")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-mse4","configMap":{"name":"release-name-varnish-enterprise-mse4"}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .volumeMounts[] | select(.name == "release-name-mse4")' |
             tee -a /dev/stderr)
@@ -285,7 +285,7 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.initContainers[]? | select(.name == "mse4-config") |
               .name'  | tee -a /dev/stderr)
     [ "${actual}" = '' ]
@@ -304,7 +304,7 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.initContainers[]? | select(.name == "mse4-config") |
               .name'  | tee -a /dev/stderr)
     [ "${actual}" = 'mse4-config' ]
@@ -325,7 +325,7 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.volumeClaimTemplates[]? | select(.metadata.name == "release-name-mse4") |
             .spec' |
             tee -a /dev/stderr)
@@ -336,7 +336,7 @@ rollingUpdate:
             tee -a /dev/stderr)
 
     local actual=$(echo "$containerObject" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-mse4")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-mse4")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-mse4","mountPath":"/data1/mse4"}' ]
 }
@@ -356,14 +356,14 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .volumeMounts[]? | select(.name == "release-name-varnish-controller")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"release-name-varnish-controller","mountPath":"/var/lib/varnish-controller"}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.volumeClaimTemplates[]? |
             select(.metadata.name == "release-name-varnish-controller") |
             .spec' |
@@ -385,7 +385,7 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .volumeMounts[]? | select(.name == "my-varnish-controller-volume")' |
             tee -a /dev/stderr)
@@ -403,7 +403,7 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.volumeClaimTemplates' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.volumeClaimTemplates' | tee -a /dev/stderr)
     [ "${actual}" == 'null' ]
 }
 
@@ -421,7 +421,7 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.volumeClaimTemplates' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.volumeClaimTemplates' | tee -a /dev/stderr)
     [ "${actual}" == '[{"metadata":{"name":"hello-pv"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"10Gi"}}}}]' ]
 }
 
@@ -444,7 +444,7 @@ rollingUpdate:
 
     local appVersion=$(app_version)
     local actual=$(echo "$object" |
-        yq -c '.spec.volumeClaimTemplates[]| select(.metadata.name == "hello-pv")' | tee -a /dev/stderr)
+        yq -o=json -I=0 '.spec.volumeClaimTemplates[]| select(.metadata.name == "hello-pv")' | tee -a /dev/stderr)
     [ "${actual}" == '{"metadata":{"name":"hello-pv"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"10Gi"}}}}' ]
 }
 
@@ -470,7 +470,7 @@ rollingUpdate:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.volumeClaimTemplates[] | select (.metadata.name == "release-name-pv")' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.volumeClaimTemplates[] | select (.metadata.name == "release-name-pv")' | tee -a /dev/stderr)
     [ "${actual}" == '{"metadata":{"name":"release-name-pv"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"10Gi"}}}}' ]
 }
 
@@ -501,6 +501,6 @@ rollingUpdate:
 
     local appVersion=$(app_version)
     local actual=$(echo "$object" |
-        yq -r -c '.spec.volumeClaimTemplates[] | select (.metadata.name == "release-name-pv")' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.volumeClaimTemplates[] | select (.metadata.name == "release-name-pv")' | tee -a /dev/stderr)
     [ "${actual}" == '{"metadata":{"name":"release-name-pv"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"10Gi"}}}}' ]
 }

--- a/varnish-enterprise/test/unit_common/common.bats
+++ b/varnish-enterprise/test/unit_common/common.bats
@@ -14,7 +14,7 @@ template=${template:-}
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.imagePullSecrets' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.imagePullSecrets' | tee -a /dev/stderr)
     [ "${actual}" == '[{"name":"quay.io-varnish-software"}]' ]
 }
 
@@ -27,7 +27,7 @@ template=${template:-}
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.serviceAccountName' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.serviceAccountName' | tee -a /dev/stderr)
     [ "${actual}" == "release-name-varnish-enterprise" ]
 }
 
@@ -40,7 +40,7 @@ template=${template:-}
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.serviceAccountName' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.serviceAccountName' | tee -a /dev/stderr)
     [ "${actual}" == "default" ]
 }
 
@@ -53,7 +53,7 @@ template=${template:-}
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.securityContext' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.securityContext' | tee -a /dev/stderr)
 
     # Note: values.yaml has 'global.podSecurityContext.fsGroup=999' as the default;
     # we're testing that the values are merged and not replaced.
@@ -71,7 +71,7 @@ template=${template:-}
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .securityContext' | tee -a /dev/stderr)
 
@@ -96,7 +96,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .securityContext' | tee -a /dev/stderr)
 
@@ -118,7 +118,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .securityContext' | tee -a /dev/stderr)
 
@@ -142,7 +142,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .securityContext' | tee -a /dev/stderr)
 
@@ -160,7 +160,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.metadata.labels.hello' |
+        yq -r -o=json -I=0 '.metadata.labels.hello' |
             tee -a /dev/stderr)
     [ "${actual}" == "varnish" ]
 }
@@ -174,7 +174,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.metadata.labels.hello' |
+        yq -r -o=json -I=0 '.metadata.labels.hello' |
             tee -a /dev/stderr)
     [ "${actual}" == "release-name" ]
 }
@@ -188,7 +188,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.metadata.annotations.hello' |
+        yq -r -o=json -I=0 '.metadata.annotations.hello' |
             tee -a /dev/stderr)
     [ "${actual}" == "varnish" ]
 }
@@ -202,7 +202,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.metadata.annotations.hello' |
+        yq -r -o=json -I=0 '.metadata.annotations.hello' |
             tee -a /dev/stderr)
     [ "${actual}" == "release-name" ]
 }
@@ -216,7 +216,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.metadata.annotations.hello' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations.hello' |
             tee -a /dev/stderr)
     [ "${actual}" == "varnish" ]
 }
@@ -230,7 +230,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.metadata.annotations.hello' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations.hello' |
             tee -a /dev/stderr)
     [ "${actual}" == "release-name" ]
 }
@@ -248,7 +248,7 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.labels' |
+        yq -r -o=json -I=0 '.spec.template.metadata.labels' |
             tee -a /dev/stderr)
 
     [ "${actual}" == '{"app.kubernetes.io/instance":"release-name","app.kubernetes.io/name":"varnish-enterprise","foo":"bar","hello":"varnish"}' ]
@@ -272,7 +272,7 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.labels' |
+        yq -r -o=json -I=0 '.spec.template.metadata.labels' |
             tee -a /dev/stderr)
 
     [ "${actual}" == '{"app.kubernetes.io/instance":"release-name","app.kubernetes.io/name":"varnish-enterprise","release-name":"release-name","release-namespace":"varnish"}' ]
@@ -296,7 +296,7 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.labels' |
+        yq -r -o=json -I=0 '.spec.template.metadata.labels' |
             tee -a /dev/stderr)
 
     [ "${actual}" == '{"app.kubernetes.io/instance":"release-name","app.kubernetes.io/name":"varnish-enterprise","release-name":"release-name","release-namespace":"default"}' ]
@@ -315,46 +315,46 @@ release-namespace: {{ .Release.Namespace }}
     # .metadata.labels
 
     local actual=$(echo "$object" |
-        yq -r -c '.metadata.labels."app.kubernetes.io/name"' |
+        yq -r -o=json -I=0 '.metadata.labels."app.kubernetes.io/name"' |
             tee -a /dev/stderr)
     [ "${actual}" == "varnish-enterprise" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.metadata.labels."app.kubernetes.io/instance"' |
+        yq -r -o=json -I=0 '.metadata.labels."app.kubernetes.io/instance"' |
             tee -a /dev/stderr)
     [ "${actual}" == "release-name" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.metadata.labels."app.kubernetes.io/version"' |
+        yq -r -o=json -I=0 '.metadata.labels."app.kubernetes.io/version"' |
             tee -a /dev/stderr)
     [ "${actual}" != "" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.metadata.labels."app.kubernetes.io/managed-by"' |
+        yq -r -o=json -I=0 '.metadata.labels."app.kubernetes.io/managed-by"' |
             tee -a /dev/stderr)
     [ "${actual}" == "Helm" ]
 
     # .spec.selector.matchLabels
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.selector.matchLabels."app.kubernetes.io/name"' |
+        yq -r -o=json -I=0 '.spec.selector.matchLabels."app.kubernetes.io/name"' |
             tee -a /dev/stderr)
     [ "${actual}" == "varnish-enterprise" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.selector.matchLabels."app.kubernetes.io/instance"' |
+        yq -r -o=json -I=0 '.spec.selector.matchLabels."app.kubernetes.io/instance"' |
             tee -a /dev/stderr)
     [ "${actual}" == "release-name" ]
 
     # .spec.template.metadata.labels
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.labels."app.kubernetes.io/name"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.labels."app.kubernetes.io/name"' |
             tee -a /dev/stderr)
     [ "${actual}" == "varnish-enterprise" ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.labels."app.kubernetes.io/instance"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.labels."app.kubernetes.io/instance"' |
             tee -a /dev/stderr)
     [ "${actual}" == "release-name" ]
 }
@@ -375,32 +375,33 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.ports[]? | select(.name == "http")' |
+        yq -r -o=json -I=0 '.ports[]? | select(.name == "http")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"http","containerPort":8090,"protocol":"TCP"}' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.startupProbe.tcpSocket.port' |
+        yq -r -o=json -I=0 '.startupProbe.tcpSocket.port' |
             tee -a /dev/stderr)
     [ "${actual}" == "8090" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.readinessProbe.tcpSocket.port' |
+        yq -r -o=json -I=0 '.readinessProbe.tcpSocket.port' |
             tee -a /dev/stderr)
     [ "${actual}" == "8090" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.livenessProbe.tcpSocket.port' |
+        yq -r -o=json -I=0 '.livenessProbe.tcpSocket.port' |
             tee -a /dev/stderr)
     [ "${actual}" == "8090" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-a", "http=0.0.0.0:8090"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-a", "http=0.0.0.0:8090"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == 'http=0.0.0.0:8090' ]
 }
@@ -422,12 +423,13 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -y '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-a", "http=127.0.0.2:8090"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-a", "http=127.0.0.2:8090"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == 'http=127.0.0.2:8090' ]
 }
@@ -450,12 +452,13 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-a", "http=$(POD_IP):8090"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-a", "http=$(POD_IP):8090"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == 'http=$(POD_IP):8090' ]
 }
@@ -476,26 +479,27 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.ports[]? | select(.name == "http")' |
+        yq -r -o=json -I=0 '.ports[]? | select(.name == "http")' |
             tee -a /dev/stderr)
     [ "${actual}" == "" ]
 
-    local actual=$(echo "$container" | yq -r -c '.startupProbe' | tee -a /dev/stderr)
+    local actual=$(echo "$container" | yq -r -o=json -I=0 '.startupProbe' | tee -a /dev/stderr)
     [ "${actual}" == "null" ]
 
-    local actual=$(echo "$container" | yq -r -c '.readinessProbe' | tee -a /dev/stderr)
+    local actual=$(echo "$container" | yq -r -o=json -I=0 '.readinessProbe' | tee -a /dev/stderr)
     [ "${actual}" == "null" ]
 
-    local actual=$(echo "$container" | yq -r -c '.livenessProbe' | tee -a /dev/stderr)
+    local actual=$(echo "$container" | yq -r -o=json -I=0 '.livenessProbe' | tee -a /dev/stderr)
     [ "${actual}" == "null" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | index(["-a", "http=0.0.0.0:6081"])' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c 'index(["-a", "http=0.0.0.0:6081"])' |
             tee -a /dev/stderr)
     [ "${actual}" == 'null' ]
 }
@@ -575,32 +579,32 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-tls"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-tls"' |
             tee -a /dev/stderr)
     [ "${actual}" = 'null' ]
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-tls")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-tls")' |
             tee -a /dev/stderr)
     [ "${actual}" = '' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.ports[]? | select(.name == "https")' |
+        yq -r -o=json -I=0 '.ports[]? | select(.name == "https")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"https","containerPort":8443,"protocol":"TCP"}' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.env[]? | select(.name == "VARNISH_TLS_CFG") | .value' |
+        yq -r -o=json -I=0 '.env[]? | select(.name == "VARNISH_TLS_CFG") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == "true" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-tls")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-tls")' |
             tee -a /dev/stderr)
     [ "${actual}" == "" ]
 }
@@ -619,27 +623,27 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-tls"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-tls"' |
             tee -a /dev/stderr)
     [ "${actual}" = '9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-tls")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-tls")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-tls","configMap":{"name":"release-name-varnish-enterprise-tls"}}' ]
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.env[]? | select(.name == "VARNISH_TLS_CFG") | .value' |
+        yq -r -o=json -I=0 '.env[]? | select(.name == "VARNISH_TLS_CFG") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == "/etc/varnish/tls.conf" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-tls")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-tls")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"release-name-config-tls","mountPath":"/etc/varnish/tls.conf","subPath":"tls.conf"}' ]
 }
@@ -655,22 +659,22 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-tls"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-tls"' |
             tee -a /dev/stderr)
     [ "${actual}" = 'null' ]
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.ports[]? | select(.name == "https")' |
+        yq -r -o=json -I=0 '.ports[]? | select(.name == "https")' |
             tee -a /dev/stderr)
     [ "${actual}" == "" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.env[]? | select(.name == "VARNISH_TLS_CFG")' |
+        yq -r -o=json -I=0 '.env[]? | select(.name == "VARNISH_TLS_CFG")' |
             tee -a /dev/stderr)
     [ "${actual}" == "" ]
 }
@@ -686,12 +690,13 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-T", "127.0.0.1:6082"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-T", "127.0.0.1:6082"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == '127.0.0.1:6082' ]
 }
@@ -709,12 +714,13 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-T", "0.0.0.0:9999"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-T", "0.0.0.0:9999"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == '0.0.0.0:9999' ]
 }
@@ -739,17 +745,19 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-a", "proxy=:8088,PROXY"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-a", "proxy=:8088,PROXY"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == 'proxy=:8088,PROXY' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-a", "proxy-sock=/tmp/varnish-proxy.sock,user=www,group=www,mode=0700,PROXY"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-a", "proxy-sock=/tmp/varnish-proxy.sock,user=www,group=www,mode=0700,PROXY"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == 'proxy-sock=/tmp/varnish-proxy.sock,user=www,group=www,mode=0700,PROXY' ]
 }
@@ -767,12 +775,13 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-a", "althttp=:8888"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-a", "althttp=:8888"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == 'althttp=:8888' ]
 }
@@ -790,12 +799,13 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-a", "althttp=/tmp/varnish.sock"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-a", "althttp=/tmp/varnish.sock"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == 'althttp=/tmp/varnish.sock' ]
 }
@@ -813,14 +823,14 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .env[]? | select(.name == "FOO")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"FOO","value":"bar"}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .env[]? | select(.name == "BAZ")' |
             tee -a /dev/stderr)
@@ -845,14 +855,14 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .env[]? | select(.name == "RELEASE_NAME")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"RELEASE_NAME","value":"release-name"}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .env[]? | select(.name == "RELEASE_NAMESPACE")' |
             tee -a /dev/stderr)
@@ -875,14 +885,14 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .env[]? | select(.name == "FOO")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"FOO","value":"bar"}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .env[]? | select(.name == "BAZ")' |
             tee -a /dev/stderr)
@@ -906,14 +916,14 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .env[]? | select(.name == "FROM_CONFIGMAP")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"FROM_CONFIGMAP","valueFrom":{"configMapKeyRef":{"key":"my-key","name":"my-configmap"}}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .env[]? | select(.name == "FROM_SECRET")' |
             tee -a /dev/stderr)
@@ -931,28 +941,32 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-t", "120"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-t", "120"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == '120' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-p", "thread_pool_min=50"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-p", "thread_pool_min=50"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == 'thread_pool_min=50' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-p", "thread_pool_max=1000"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-p", "thread_pool_max=1000"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == 'thread_pool_max=1000' ]
 
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-p", "thread_pool_timeout=120"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-p", "thread_pool_timeout=120"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == 'thread_pool_timeout=120' ]
 }
@@ -972,28 +986,32 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-t", "240"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-t", "240"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == '240' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-p", "thread_pool_min=300"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-p", "thread_pool_min=300"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == 'thread_pool_min=300' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-p", "thread_pool_max=5000"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-p", "thread_pool_max=5000"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == 'thread_pool_max=5000' ]
 
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-p", "thread_pool_timeout=500"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-p", "thread_pool_timeout=500"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == 'thread_pool_timeout=500' ]
 }
@@ -1010,12 +1028,13 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-p", "feature=+http2"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-p", "feature=+http2"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == 'feature=+http2' ]
 }
@@ -1032,12 +1051,13 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-p", "feature=+http2"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-p", "feature=+http2"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == 'feature=+http2' ]
 }
@@ -1057,17 +1077,19 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-p", "feature=+http2"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-p", "feature=+http2"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == 'feature=+http2' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-a", "proxy=:8088,PROXY"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-a", "proxy=:8088,PROXY"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == 'proxy=:8088,PROXY' ]
 }
@@ -1087,17 +1109,19 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-p", "feature=+http2"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-p", "feature=+http2"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == 'feature=+http2' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-a", "proxy=:8088,PROXY"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-a", "proxy=:8088,PROXY"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == 'proxy=:8088,PROXY' ]
 }
@@ -1116,17 +1140,19 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-p", "feature=+http2,+validate_headers"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-p", "feature=+http2,+validate_headers"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == 'feature=+http2,+validate_headers' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-p", "backend_idle_timeout=60"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-p", "backend_idle_timeout=60"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == 'backend_idle_timeout=60' ]
 }
@@ -1144,7 +1170,7 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-hello")' |
             tee -a /dev/stderr)
 
@@ -1167,7 +1193,7 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "release-name-hello")' |
             tee -a /dev/stderr)
 
@@ -1187,7 +1213,7 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .volumeMounts[]? | select(.name == "varnish-data")' |
             tee -a /dev/stderr)
@@ -1211,7 +1237,7 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .volumeMounts[]? | select(.name == "release-name-data")' |
             tee -a /dev/stderr)
@@ -1233,7 +1259,7 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.volumes[]? | select(.name == "varnish-data")' |
             tee -a /dev/stderr)
 
@@ -1258,7 +1284,7 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.volumes[]? | select(.name == "release-name-data")' |
             tee -a /dev/stderr)
 
@@ -1277,27 +1303,28 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-secret"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-secret"' |
             tee -a /dev/stderr)
     [ "${actual}" = '4ad139339508eb77f3875735b8415516f14f388e228071faa1d2b080429cdd9b' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-secret")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-secret")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-secret","secret":{"secretName":"release-name-varnish-enterprise-secret"}}' ]
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-S", "/etc/varnish/secret"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-S", "/etc/varnish/secret"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == '/etc/varnish/secret' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-secret")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-secret")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"release-name-config-secret","mountPath":"/etc/varnish/secret","subPath":"secret"}' ]
 }
@@ -1316,27 +1343,28 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-secret"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-secret"' |
             tee -a /dev/stderr)
     [ "${actual}" = 'null' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-secret")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-secret")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-secret","secret":{"secretName":"external-secret"}}' ]
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-S", "/etc/varnish/secret"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-S", "/etc/varnish/secret"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == '/etc/varnish/secret' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-secret")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-secret")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"release-name-config-secret","mountPath":"/etc/varnish/secret","subPath":"varnish-password"}' ]
 }
@@ -1425,27 +1453,27 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-secret"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-secret"' |
             tee -a /dev/stderr)
     [ "${actual}" = 'null' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-secret")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-secret")' |
             tee -a /dev/stderr)
     [ "${actual}" = '' ]
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.env[]? | select(.name == "VARNISH_SECRET_FILE") | .value' |
+        yq -r -o=json -I=0 '.env[]? | select(.name == "VARNISH_SECRET_FILE") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == '' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-secret")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-secret")' |
             tee -a /dev/stderr)
     [ "${actual}" == '' ]
 }
@@ -1461,37 +1489,38 @@ release-namespace: {{ .Release.Namespace }}
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-vcl"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-vcl"' |
             tee -a /dev/stderr)
     [ "${actual}" = 'null' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-shared")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-shared")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-shared","emptyDir":{"medium":"Memory"}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '' ]
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-f", "/etc/varnish/default.vcl"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-f", "/etc/varnish/default.vcl"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == '/etc/varnish/default.vcl' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-shared")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-shared")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-shared","mountPath":"/etc/varnish/shared"}' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '' ]
 }
@@ -1524,37 +1553,38 @@ backend release-name {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-vcl"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-vcl"' |
             tee -a /dev/stderr)
     [ "${actual}" = 'e71c17a8bb11a3944b9029906deac70c7f3643ceec87cb1e8a304b7b8c92138d' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-shared")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-shared")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-shared","emptyDir":{"medium":"Memory"}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-vcl","configMap":{"name":"release-name-varnish-enterprise-vcl"}}' ]
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-f", "/etc/varnish/default.vcl"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-f", "/etc/varnish/default.vcl"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == '/etc/varnish/default.vcl' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-shared")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-shared")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-shared","mountPath":"/etc/varnish/shared"}' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-vcl","mountPath":"/etc/varnish/default.vcl","subPath":"default.vcl"}' ]
 }
@@ -1588,37 +1618,38 @@ backend release-name {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-vcl"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-vcl"' |
             tee -a /dev/stderr)
     [ "${actual}" = 'e71c17a8bb11a3944b9029906deac70c7f3643ceec87cb1e8a304b7b8c92138d' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-shared")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-shared")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-shared","emptyDir":{"medium":"Memory"}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-vcl","configMap":{"name":"release-name-varnish-enterprise-vcl"}}' ]
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-f", "/etc/varnish/default.vcl"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-f", "/etc/varnish/default.vcl"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == '/etc/varnish/default.vcl' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-shared")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-shared")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-shared","mountPath":"/etc/varnish/shared"}' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-vcl","mountPath":"/etc/varnish/default.vcl","subPath":"default.vcl"}' ]
 }
@@ -1668,52 +1699,53 @@ backend release-name {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-vcl"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-vcl"' |
             tee -a /dev/stderr)
     [ "${actual}" = 'e71c17a8bb11a3944b9029906deac70c7f3643ceec87cb1e8a304b7b8c92138d' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-vcl-main-vcl"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-vcl-main-vcl"' |
             tee -a /dev/stderr)
     [ "${actual}" = '11060980fc16de8bee3d626bfa600a13ab5db83471fd93fe60e15437f2d568b5' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-shared")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-shared")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-shared","emptyDir":{"medium":"Memory"}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-vcl","configMap":{"name":"release-name-varnish-enterprise-vcl"}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl-main-vcl")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl-main-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-vcl-main-vcl","configMap":{"name":"release-name-varnish-enterprise-vcl-main-vcl"}}' ]
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-f", "/etc/varnish/default.vcl"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-f", "/etc/varnish/default.vcl"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == '/etc/varnish/default.vcl' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-shared")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-shared")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-shared","mountPath":"/etc/varnish/shared"}' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-vcl","mountPath":"/etc/varnish/default.vcl","subPath":"default.vcl"}' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl-main-vcl")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-vcl-main-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-vcl-main-vcl","mountPath":"/etc/varnish/main.vcl","subPath":"main.vcl"}' ]
 }
@@ -1764,52 +1796,53 @@ backend release-name {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-vcl"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-vcl"' |
             tee -a /dev/stderr)
     [ "${actual}" = 'e71c17a8bb11a3944b9029906deac70c7f3643ceec87cb1e8a304b7b8c92138d' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-vcl-main-vcl"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-vcl-main-vcl"' |
             tee -a /dev/stderr)
     [ "${actual}" = '11060980fc16de8bee3d626bfa600a13ab5db83471fd93fe60e15437f2d568b5' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-shared")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-shared")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-shared","emptyDir":{"medium":"Memory"}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-vcl","configMap":{"name":"release-name-varnish-enterprise-vcl"}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl-main-vcl")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl-main-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-vcl-main-vcl","configMap":{"name":"release-name-varnish-enterprise-vcl-main-vcl"}}' ]
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-f", "/etc/varnish/default.vcl"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-f", "/etc/varnish/default.vcl"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == '/etc/varnish/default.vcl' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-shared")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-shared")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-shared","mountPath":"/etc/varnish/shared"}' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-vcl","mountPath":"/etc/varnish/default.vcl","subPath":"default.vcl"}' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl-main-vcl")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-vcl-main-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-vcl-main-vcl","mountPath":"/etc/varnish/main.vcl","subPath":"main.vcl"}' ]
 }
@@ -1861,52 +1894,53 @@ backend release-name {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-vcl"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-vcl"' |
             tee -a /dev/stderr)
     [ "${actual}" = 'e71c17a8bb11a3944b9029906deac70c7f3643ceec87cb1e8a304b7b8c92138d' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-vcl-main-vcl"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-vcl-main-vcl"' |
             tee -a /dev/stderr)
     [ "${actual}" = '11060980fc16de8bee3d626bfa600a13ab5db83471fd93fe60e15437f2d568b5' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-shared")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-shared")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-shared","emptyDir":{"medium":"Memory"}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-vcl","configMap":{"name":"release-name-varnish-enterprise-vcl"}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl-main-vcl")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-vcl-main-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-vcl-main-vcl","configMap":{"name":"release-name-varnish-enterprise-vcl-main-vcl"}}' ]
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-f", "/etc/varnish/varnish.vcl"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-f", "/etc/varnish/varnish.vcl"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == '/etc/varnish/varnish.vcl' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-shared")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-shared")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-shared","mountPath":"/etc/varnish/shared"}' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-vcl","mountPath":"/etc/varnish/varnish.vcl","subPath":"varnish.vcl"}' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl-main-vcl")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-vcl-main-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-vcl-main-vcl","mountPath":"/etc/varnish/main.vcl","subPath":"main.vcl"}' ]
 }
@@ -1993,17 +2027,18 @@ backend default {
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-f", "/etc/varnish/varnish.vcl"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-f", "/etc/varnish/varnish.vcl"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == '/etc/varnish/varnish.vcl' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"release-name-config-vcl","mountPath":"/etc/varnish/varnish.vcl","subPath":"varnish.vcl"}' ]
 
@@ -2016,7 +2051,7 @@ backend default {
         . || echo "---") |
         tee -a /dev/stderr)
 
-    local actual=$(echo "$object" | yq -r -c '.data' | tee -a /dev/stderr)
+    local actual=$(echo "$object" | yq -r -o=json -I=0 '.data' | tee -a /dev/stderr)
     [ "${actual}" == '{"varnish.vcl":"\nvcl 4.1;\n\nbackend default {\n  .host = \"127.0.0.1\";\n  .port = \"8080\";\n}\n"}' ]
 }
 
@@ -2032,17 +2067,18 @@ backend default {
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-f", "/etc/varnish/varnish.vcl"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-f", "/etc/varnish/varnish.vcl"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == '/etc/varnish/varnish.vcl' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" == '' ]
 }
@@ -2064,22 +2100,23 @@ backend default {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "varnish-vcl-tenant1")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "varnish-vcl-tenant1")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"configMap":{"name":"varnish-vcl-tenant1"},"name":"varnish-vcl-tenant1"}' ]
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-f", "/etc/varnish/varnish.vcl"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-f", "/etc/varnish/varnish.vcl"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == '/etc/varnish/varnish.vcl' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "varnish-vcl-tenant1")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "varnish-vcl-tenant1")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"mountPath":"/etc/varnish/tenant1.vcl","name":"varnish-vcl-tenant1","subpath":"tenant1.vcl"}' ]
 }
@@ -2103,27 +2140,28 @@ vcl.use vcl_main
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-cmdfile"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-cmdfile"' |
             tee -a /dev/stderr)
     [ "${actual}" = '624d35eb30614898dff2f0a0d0b877fb27f394debc7f8316605a9208ed5b1c6d' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-cmdfile")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-cmdfile")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-cmdfile","configMap":{"name":"release-name-varnish-enterprise-cmdfile"}}' ]
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-I", "/etc/varnish/cmds.cli"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-I", "/etc/varnish/cmds.cli"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == '/etc/varnish/cmds.cli' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-cmdfile")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-cmdfile")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"release-name-config-cmdfile","mountPath":"/etc/varnish/cmds.cli","subPath":"cmds.cli"}' ]
 }
@@ -2148,17 +2186,18 @@ vcl.use vcl_main
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-I", "/etc/varnish/cmdfile"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-I", "/etc/varnish/cmdfile"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == '/etc/varnish/cmdfile' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-cmdfile")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-cmdfile")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"release-name-config-cmdfile","mountPath":"/etc/varnish/cmdfile","subPath":"cmds.cli"}' ]
 }
@@ -2198,17 +2237,17 @@ vcl.use vcl_main
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.image' |
+        yq -r -o=json -I=0 '.image' |
             tee -a /dev/stderr)
     [ "${actual}" == "docker-repo.local/varnish-software/varnish-plus:latest" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.imagePullPolicy' |
+        yq -r -o=json -I=0 '.imagePullPolicy' |
             tee -a /dev/stderr)
     [ "${actual}" == "Always" ]
 }
@@ -2221,7 +2260,7 @@ vcl.use vcl_main
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .startupProbe' | tee -a /dev/stderr)
 
@@ -2241,7 +2280,7 @@ vcl.use vcl_main
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .startupProbe' | tee -a /dev/stderr)
 
@@ -2262,7 +2301,7 @@ vcl.use vcl_main
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .startupProbe' | tee -a /dev/stderr)
 
@@ -2285,7 +2324,7 @@ vcl.use vcl_main
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .startupProbe' | tee -a /dev/stderr)
 
@@ -2306,7 +2345,7 @@ vcl.use vcl_main
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .startupProbe' | tee -a /dev/stderr)
 
@@ -2326,7 +2365,7 @@ vcl.use vcl_main
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .readinessProbe' | tee -a /dev/stderr)
 
@@ -2347,7 +2386,7 @@ vcl.use vcl_main
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .readinessProbe' | tee -a /dev/stderr)
 
@@ -2370,7 +2409,7 @@ vcl.use vcl_main
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .readinessProbe' | tee -a /dev/stderr)
 
@@ -2391,7 +2430,7 @@ vcl.use vcl_main
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .readinessProbe' | tee -a /dev/stderr)
 
@@ -2407,7 +2446,7 @@ vcl.use vcl_main
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .readinessProbe' | tee -a /dev/stderr)
 
@@ -2427,7 +2466,7 @@ vcl.use vcl_main
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .livenessProbe' | tee -a /dev/stderr)
 
@@ -2448,7 +2487,7 @@ vcl.use vcl_main
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .livenessProbe' | tee -a /dev/stderr)
 
@@ -2471,7 +2510,7 @@ vcl.use vcl_main
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .livenessProbe' | tee -a /dev/stderr)
 
@@ -2492,7 +2531,7 @@ vcl.use vcl_main
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .livenessProbe' | tee -a /dev/stderr)
 
@@ -2508,7 +2547,7 @@ vcl.use vcl_main
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .livenessProbe' | tee -a /dev/stderr)
 
@@ -2528,7 +2567,7 @@ vcl.use vcl_main
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .resources' | tee -a /dev/stderr)
 
@@ -2554,7 +2593,7 @@ requests:
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .resources' | tee -a /dev/stderr)
 
@@ -2580,7 +2619,7 @@ requests:
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .resources' | tee -a /dev/stderr)
 
@@ -2612,7 +2651,7 @@ requests:
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .resources' | tee -a /dev/stderr)
 
@@ -2627,7 +2666,7 @@ requests:
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .resources' | tee -a /dev/stderr)
 
@@ -2643,7 +2682,7 @@ requests:
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"tier":"edge"}' ]
 }
@@ -2657,7 +2696,7 @@ requests:
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"tier":"release-name-edge"}' ]
 }
@@ -2670,7 +2709,7 @@ requests:
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.nodeSelector' | tee -a /dev/stderr)
 
     [ "${actual}" == 'null' ]
 }
@@ -2686,7 +2725,7 @@ requests:
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.tolerations' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.tolerations' | tee -a /dev/stderr)
 
     [ "${actual}" == '[{"effect":"NoSchedule","key":"far-network-disk","operator":"Exists"}]' ]
 }
@@ -2706,7 +2745,7 @@ requests:
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.tolerations' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.tolerations' | tee -a /dev/stderr)
 
     [ "${actual}" == '[{"key":"ban-release-name","operator":"Exists","effect":"NoSchedule"}]' ]
 }
@@ -2719,7 +2758,7 @@ requests:
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.tolerations' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.tolerations' | tee -a /dev/stderr)
 
     [ "${actual}" == 'null' ]
 }
@@ -2734,7 +2773,7 @@ requests:
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.affinity' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.affinity' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"foo":"bar"}},"topologyKey":"kubernetes.io/hostname"}]}}' ]
 }
@@ -2758,7 +2797,7 @@ podAntiAffinity:
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '.spec.template.spec.affinity' | tee -a /dev/stderr)
+        yq -r -o=json -I=0 '.spec.template.spec.affinity' | tee -a /dev/stderr)
 
     [ "${actual}" == '{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"app.kubernetes.io/name":"varnish-enterprise","app.kubernetes.io/instance":"release-name"}},"topologyKey":"kubernetes.io/hostname"}]}}' ]
 }
@@ -2775,7 +2814,7 @@ podAntiAffinity:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .command[] | select(match("memory_target")) | split("=")[1]' |
             tee -a /dev/stderr)
@@ -2794,7 +2833,7 @@ podAntiAffinity:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .command[] | select(match("memory_target")) | split("=")[1]' |
             tee -a /dev/stderr)
@@ -2846,27 +2885,28 @@ env: {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-mse"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-mse"' |
             tee -a /dev/stderr)
     [ "${actual}" = '743d1704f0c1d9c5dcbadb6ecf463947ef37f1e8c3db0e58ac150ecd5a1a74a8' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-mse")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-mse")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-mse","configMap":{"name":"release-name-varnish-enterprise-mse"}}' ]
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[ index("-s") + 1 ] | split(",")[1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[ index("-s") + 1 ] | split(",")[1]' |
             tee -a /dev/stderr)
     [ "${actual}" == "/etc/varnish/mse.conf" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-mse")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-mse")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"release-name-config-mse","mountPath":"/etc/varnish/mse.conf","subPath":"mse.conf"}' ]
 }
@@ -2882,27 +2922,28 @@ env: {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-mse"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-mse"' |
             tee -a /dev/stderr)
     [ "${actual}" = 'null' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-mse")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-mse")' |
             tee -a /dev/stderr)
     [ "${actual}" = '' ]
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[ index("-s") + 1 ] | split(",")[1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[ index("-s") + 1 ] | split(",")[1]' |
             tee -a /dev/stderr)
     [ "${actual}" == "null" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-mse")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-mse")' |
             tee -a /dev/stderr)
     [ "${actual}" == '' ]
 }
@@ -2934,9 +2975,10 @@ env: {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
-             .command | .[ index("-s") + 1 ] | split(",")[0]' |
+             .command' |
+            jq -r -c '.[ index("-s") + 1 ] | split(",")[0]' |
             tee -a /dev/stderr)
 
     [ "${actual}" == "mse4" ]
@@ -2954,9 +2996,10 @@ env: {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
-             .command | .[ index("-s") + 1 ] | split(",")[0]' |
+             .command' |
+            jq -r -c '.[ index("-s") + 1 ] | split(",")[0]' |
             tee -a /dev/stderr)
 
     [ "${actual}" == "mse4" ]
@@ -2990,7 +3033,7 @@ env: {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .command[] | select(match("memory_target")) | split("=")[1]' |
             tee -a /dev/stderr)
@@ -3010,7 +3053,7 @@ env: {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise") |
             .command[] | select(match("memory_target")) | split("=")[1]' |
             tee -a /dev/stderr)
@@ -3059,27 +3102,28 @@ env: {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-mse4"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-mse4"' |
             tee -a /dev/stderr)
     [ "${actual}" = '4b7c702a1f2833fe90663595430b607bed979cacf9d523adb8ce2180f06f4102' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-mse4")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-mse4")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-mse4","configMap":{"name":"release-name-varnish-enterprise-mse4"}}' ]
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[ index("-s") + 1 ] | split(",")[1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[ index("-s") + 1 ] | split(",")[1]' |
             tee -a /dev/stderr)
     [ "${actual}" == "/etc/varnish/mse4.conf" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-mse4")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-mse4")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"release-name-config-mse4","mountPath":"/etc/varnish/mse4.conf","subPath":"mse4.conf"}' ]
 }
@@ -3096,27 +3140,28 @@ env: {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-mse4"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-mse4"' |
             tee -a /dev/stderr)
     [ "${actual}" = 'null' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-mse4")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-mse4")' |
             tee -a /dev/stderr)
     [ "${actual}" = '' ]
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[ index("-s") + 1 ] | split(",")[1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[ index("-s") + 1 ] | split(",")[1]' |
             tee -a /dev/stderr)
     [ "${actual}" == "null" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-mse4")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-mse4")' |
             tee -a /dev/stderr)
     [ "${actual}" == '' ]
 }
@@ -3132,11 +3177,11 @@ env: {
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
-    local actual=$(echo "$container" | yq -r -c '.lifecycle' | tee -a /dev/stderr)
+    local actual=$(echo "$container" | yq -r -o=json -I=0 '.lifecycle' | tee -a /dev/stderr)
     [ "${actual}" == "null" ]
 }
 
@@ -3152,11 +3197,11 @@ env: {
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
-    local actual=$(echo "$container" | yq -r -c '.lifecycle' | tee -a /dev/stderr)
+    local actual=$(echo "$container" | yq -r -o=json -I=0 '.lifecycle' | tee -a /dev/stderr)
     [ "${actual}" == '{"preStop":{"exec":{"command":["/bin/sleep","120"]}}}' ]
 }
 
@@ -3174,11 +3219,11 @@ env: {
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
-    local actual=$(echo "$container" | yq -r -c '.lifecycle' | tee -a /dev/stderr)
+    local actual=$(echo "$container" | yq -r -o=json -I=0 '.lifecycle' | tee -a /dev/stderr)
     [ "${actual}" == '{"preStop":{"exec":{"command":["/bin/sleep","120"]}}}' ]
 }
 
@@ -3193,11 +3238,11 @@ env: {
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
-    local actual=$(echo "$container" | yq -r -c '.lifecycle' | tee -a /dev/stderr)
+    local actual=$(echo "$container" | yq -r -o=json -I=0 '.lifecycle' | tee -a /dev/stderr)
     [ "${actual}" == "null" ]
 }
 
@@ -3214,11 +3259,11 @@ env: {
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
-    local actual=$(echo "$container" | yq -r -c '.lifecycle' | tee -a /dev/stderr)
+    local actual=$(echo "$container" | yq -r -o=json -I=0 '.lifecycle' | tee -a /dev/stderr)
     [ "${actual}" == '{"preStop":{"exec":{"command":["/bin/sleep","120"]}}}' ]
 }
 
@@ -3236,11 +3281,11 @@ env: {
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
-    local actual=$(echo "$container" | yq -r -c '.lifecycle' | tee -a /dev/stderr)
+    local actual=$(echo "$container" | yq -r -o=json -I=0 '.lifecycle' | tee -a /dev/stderr)
     [[ "${actual}" == *"MEMPOOL.sess"* ]]
     [[ "${actual}" == *"sleep 5"* ]]
     [[ "${actual}" == *"sleep 30"* ]]
@@ -3259,20 +3304,22 @@ env: {
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
-    local actual=$(echo "$container" | yq -r -c '.lifecycle' | tee -a /dev/stderr)
+    local actual=$(echo "$container" | yq -r -o=json -I=0 '.lifecycle' | tee -a /dev/stderr)
     [ "${actual}" = "null" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-p", "shutdown_close=off"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-p", "shutdown_close=off"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == 'shutdown_close=off' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-p", "shutdown_delay=120"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-p", "shutdown_delay=120"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == 'shutdown_delay=120' ]
 }
@@ -3288,7 +3335,7 @@ env: {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.terminationGracePeriodSeconds' |
             tee -a /dev/stderr)
     [ "${actual}" == "null" ]
@@ -3306,7 +3353,7 @@ env: {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.terminationGracePeriodSeconds' |
             tee -a /dev/stderr)
     [ "${actual}" == "120" ]
@@ -3324,7 +3371,7 @@ env: {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.terminationGracePeriodSeconds' |
             tee -a /dev/stderr)
     [ "${actual}" == "120" ]
@@ -3343,7 +3390,7 @@ env: {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.terminationGracePeriodSeconds' |
             tee -a /dev/stderr)
     [ "${actual}" == "180" ]
@@ -3363,7 +3410,7 @@ env: {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.terminationGracePeriodSeconds' |
             tee -a /dev/stderr)
     [ "${actual}" == "180" ]
@@ -3384,7 +3431,7 @@ env: {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.terminationGracePeriodSeconds' |
             tee -a /dev/stderr)
     [ "${actual}" == "180" ]
@@ -3404,7 +3451,7 @@ env: {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.terminationGracePeriodSeconds' |
             tee -a /dev/stderr)
     [ "${actual}" == "180" ]
@@ -3421,12 +3468,12 @@ env: {
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? |
             select(.name == "varnish-enterprise-agent")' | tee -a /dev/stderr)
     [ "${actual}" == "" ]
@@ -3445,22 +3492,23 @@ env: {
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.env[]? | select(.name == "VARNISH_CONTROLLER_AGENT_NAME")' |
+        yq -r -o=json -I=0 '.env[]? | select(.name == "VARNISH_CONTROLLER_AGENT_NAME")' |
             tee -a /dev/stderr)
     [ "${actual}" == '' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-I", "/etc/varnish/shared/agent/cmds.cli"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-I", "/etc/varnish/shared/agent/cmds.cli"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == '/etc/varnish/shared/agent/cmds.cli' ]
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent")' |
             tee -a /dev/stderr)
 
@@ -3469,7 +3517,7 @@ env: {
     [ "${actual}" = "true" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.env[]? | select(.name == "VARNISH_CONTROLLER_AGENT_NAME") | .valueFrom' |
+        yq -r -o=json -I=0 '.env[]? | select(.name == "VARNISH_CONTROLLER_AGENT_NAME") | .valueFrom' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"fieldRef":{"fieldPath":"metadata.name"}}' ]
 }
@@ -3488,22 +3536,23 @@ env: {
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.env[]? | select(.name == "VARNISH_CONTROLLER_AGENT_NAME") | .valueFrom' |
+        yq -r -o=json -I=0 '.env[]? | select(.name == "VARNISH_CONTROLLER_AGENT_NAME") | .valueFrom' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"fieldRef":{"fieldPath":"metadata.name"}}' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-I", "/var/lib/varnish-controller/varnish-controller-agent/$(VARNISH_CONTROLLER_AGENT_NAME)/cmds.cli"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-I", "/var/lib/varnish-controller/varnish-controller-agent/$(VARNISH_CONTROLLER_AGENT_NAME)/cmds.cli"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == '/var/lib/varnish-controller/varnish-controller-agent/$(VARNISH_CONTROLLER_AGENT_NAME)/cmds.cli' ]
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent")' |
             tee -a /dev/stderr)
 
@@ -3512,7 +3561,7 @@ env: {
     [ "${actual}" = "true" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.env[]? | select(.name == "VARNISH_CONTROLLER_AGENT_NAME") | .valueFrom' |
+        yq -r -o=json -I=0 '.env[]? | select(.name == "VARNISH_CONTROLLER_AGENT_NAME") | .valueFrom' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"fieldRef":{"fieldPath":"metadata.name"}}' ]
 }
@@ -3533,22 +3582,23 @@ env: {
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.env[]? | select(.name == "VARNISH_CONTROLLER_AGENT_NAME") | .value' |
+        yq -r -o=json -I=0 '.env[]? | select(.name == "VARNISH_CONTROLLER_AGENT_NAME") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == 'release-name' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[index(["-I", "/var/lib/varnish-controller/varnish-controller-agent/$(VARNISH_CONTROLLER_AGENT_NAME)/cmds.cli"]) + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index(["-I", "/var/lib/varnish-controller/varnish-controller-agent/$(VARNISH_CONTROLLER_AGENT_NAME)/cmds.cli"]) + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == '/var/lib/varnish-controller/varnish-controller-agent/$(VARNISH_CONTROLLER_AGENT_NAME)/cmds.cli' ]
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent")' |
             tee -a /dev/stderr)
 
@@ -3557,7 +3607,7 @@ env: {
     [ "${actual}" = "true" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.env[]? | select(.name == "VARNISH_CONTROLLER_AGENT_NAME") | .value' |
+        yq -r -o=json -I=0 '.env[]? | select(.name == "VARNISH_CONTROLLER_AGENT_NAME") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == 'release-name' ]
 }
@@ -3577,17 +3627,17 @@ env: {
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.env[]? | select(.name == "VARNISH_CONTROLLER_VARNISH_HOST") | .valueFrom' |
+        yq -r -o=json -I=0 '.env[]? | select(.name == "VARNISH_CONTROLLER_VARNISH_HOST") | .valueFrom' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"fieldRef":{"fieldPath":"status.podIP"}}' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.env[]? | select(.name == "VARNISH_CONTROLLER_VARNISH_PORT") | .value' |
+        yq -r -o=json -I=0 '.env[]? | select(.name == "VARNISH_CONTROLLER_VARNISH_PORT") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == "8090" ]
 }
@@ -3625,27 +3675,28 @@ env: {
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.env[]? | select(.name == "VARNISH_CONTROLLER_VARNISH_ADMIN_HOST") | .value' |
+        yq -r -o=json -I=0 '.env[]? | select(.name == "VARNISH_CONTROLLER_VARNISH_ADMIN_HOST") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == "0.0.0.0" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.env[]? | select(.name == "VARNISH_CONTROLLER_VARNISH_ADMIN_PORT") | .value' |
+        yq -r -o=json -I=0 '.env[]? | select(.name == "VARNISH_CONTROLLER_VARNISH_ADMIN_PORT") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == "9999" ]
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[ index ("-T") + 1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[index("-T") + 1]' |
             tee -a /dev/stderr)
     [ "${actual}" == "0.0.0.0:9999" ]
 }
@@ -3664,12 +3715,12 @@ env: {
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "release-name-config-secret")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "release-name-config-secret")' |
             tee -a /dev/stderr)
     [ "${actual}" = '{"name":"release-name-config-secret","secret":{"secretName":"external-secret"}}' ]
 }
@@ -3700,7 +3751,7 @@ env: {
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_PRIVATE_TOKEN") | .value' |
             tee -a /dev/stderr)
@@ -3721,7 +3772,7 @@ env: {
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .securityContext' | tee -a /dev/stderr)
 
@@ -3749,7 +3800,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .securityContext' | tee -a /dev/stderr)
 
@@ -3774,7 +3825,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .securityContext' | tee -a /dev/stderr)
 
@@ -3801,7 +3852,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .securityContext' | tee -a /dev/stderr)
 
@@ -3822,28 +3873,28 @@ release-namespace: to-be-override
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_SERVER") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == '$(VARNISH_CONTROLLER_NATS_USER):$(VARNISH_CONTROLLER_NATS_PASS)@$(VARNISH_CONTROLLER_NATS_HOST)' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_USER") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == 'varnish-controller' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_PASS") | .valueFrom' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"secretKeyRef":{"name":"varnish-controller-credentials","key":"nats-varnish-password"}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_HOST") | .value' |
             tee -a /dev/stderr)
@@ -3865,28 +3916,28 @@ release-namespace: to-be-override
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_SERVER") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == '$(VARNISH_CONTROLLER_NATS_USER):$(VARNISH_CONTROLLER_NATS_PASS)@$(VARNISH_CONTROLLER_NATS_HOST)' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_USER") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == 'varnish-controller' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_PASS") | .valueFrom' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"secretKeyRef":{"name":"varnish-controller-credentials","key":"nats-varnish-password"}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_HOST") | .value' |
             tee -a /dev/stderr)
@@ -3910,28 +3961,28 @@ release-namespace: to-be-override
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_SERVER") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == '$(VARNISH_CONTROLLER_NATS_USER):$(VARNISH_CONTROLLER_NATS_PASS)@$(VARNISH_CONTROLLER_NATS_HOST)' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_USER") | .value' |
             tee -a /dev/stderr)
     [ "${actual}" == 'varnish-controller' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_PASS") | .valueFrom' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"secretKeyRef":{"name":"external-secret","key":"nats-password"}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_HOST") | .value' |
             tee -a /dev/stderr)
@@ -3952,28 +4003,28 @@ release-namespace: to-be-override
         . || echo "---") | tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_HOST")' |
             tee -a /dev/stderr)
     [ "${actual}" == '' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_USER")' |
             tee -a /dev/stderr)
     [ "${actual}" == '' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_PASS")' |
             tee -a /dev/stderr)
     [ "${actual}" == '' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_NATS_SERVER") | .value' |
             tee -a /dev/stderr)
@@ -4010,7 +4061,7 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_LOG")' |
             tee -a /dev/stderr)
@@ -4033,14 +4084,14 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .env[]? | select(.name == "FOO")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"FOO","value":"bar"}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .env[]? | select(.name == "BAZ")' |
             tee -a /dev/stderr)
@@ -4067,14 +4118,14 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .env[]? | select(.name == "RELEASE_NAME")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"RELEASE_NAME","value":"release-name"}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .env[]? | select(.name == "RELEASE_NAMESPACE")' |
             tee -a /dev/stderr)
@@ -4098,14 +4149,14 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .env[]? | select(.name == "FOO")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"FOO","value":"bar"}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .env[]? | select(.name == "BAZ")' |
             tee -a /dev/stderr)
@@ -4131,14 +4182,14 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .env[]? | select(.name == "FROM_CONFIGMAP")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"FROM_CONFIGMAP","valueFrom":{"configMapKeyRef":{"key":"my-key","name":"my-configmap"}}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .env[]? | select(.name == "FROM_SECRET")' |
             tee -a /dev/stderr)
@@ -4158,7 +4209,7 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_TAGS")' |
             tee -a /dev/stderr)
@@ -4180,7 +4231,7 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_TAGS")' |
             tee -a /dev/stderr)
@@ -4200,14 +4251,14 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_LONGITUDE")' |
             tee -a /dev/stderr)
     [ "${actual}" == '' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_LATITUDE")' |
             tee -a /dev/stderr)
@@ -4229,14 +4280,14 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_LATITUDE")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"VARNISH_CONTROLLER_LATITUDE","value":"37.354107"}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .env[]? | select(.name == "VARNISH_CONTROLLER_LONGITUDE")' |
             tee -a /dev/stderr)
@@ -4259,7 +4310,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .resources' | tee -a /dev/stderr)
 
@@ -4288,7 +4339,7 @@ requests:
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .resources' | tee -a /dev/stderr)
 
@@ -4317,7 +4368,7 @@ requests:
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .resources' | tee -a /dev/stderr)
 
@@ -4352,7 +4403,7 @@ requests:
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .resources' | tee -a /dev/stderr)
 
@@ -4369,7 +4420,7 @@ requests:
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .resources' | tee -a /dev/stderr)
 
@@ -4389,14 +4440,14 @@ requests:
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .volumeMounts[]? | select(.name == "release-name-varnish-controller")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"release-name-varnish-controller","mountPath":"/var/lib/varnish-controller"}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.volumes[]? | select(.name == "release-name-varnish-controller")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"release-name-varnish-controller","emptyDir":{}}' ]
@@ -4415,12 +4466,12 @@ requests:
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" = '' ]
 }
@@ -4447,12 +4498,12 @@ backend {{ .Release.Name }} {
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"release-name-config-vcl","mountPath":"/etc/varnish/default.vcl","subPath":"default.vcl"}' ]
 }
@@ -4480,12 +4531,12 @@ backend {{ .Release.Name }} {
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"release-name-config-vcl","mountPath":"/etc/varnish/default.vcl","subPath":"default.vcl"}' ]
 }
@@ -4521,17 +4572,17 @@ default {{ .Release.Name }} {
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"release-name-config-vcl","mountPath":"/etc/varnish/default.vcl","subPath":"default.vcl"}' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl-main-vcl")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-vcl-main-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"release-name-config-vcl-main-vcl","mountPath":"/etc/varnish/main.vcl","subPath":"main.vcl"}' ]
 }
@@ -4568,17 +4619,17 @@ default {{ .Release.Name }} {
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"release-name-config-vcl","mountPath":"/etc/varnish/default.vcl","subPath":"default.vcl"}' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl-main-vcl")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-vcl-main-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"release-name-config-vcl-main-vcl","mountPath":"/etc/varnish/main.vcl","subPath":"main.vcl"}' ]
 }
@@ -4616,17 +4667,17 @@ default {{ .Release.Name }} {
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"release-name-config-vcl","mountPath":"/etc/varnish/varnish.vcl","subPath":"varnish.vcl"}' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl-main-vcl")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-vcl-main-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"release-name-config-vcl-main-vcl","mountPath":"/etc/varnish/main.vcl","subPath":"main.vcl"}' ]
 }
@@ -4654,12 +4705,12 @@ backend default {
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
+        yq -r -o=json -I=0 '.volumeMounts[] | select(.name == "release-name-config-vcl")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"release-name-config-vcl","mountPath":"/etc/varnish/varnish.vcl","subPath":"varnish.vcl"}' ]
 }
@@ -4677,14 +4728,14 @@ backend default {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .command' |
             tee -a /dev/stderr)
     [ "${actual}" == '["/usr/bin/varnish-controller-agent"]' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .args' |
             tee -a /dev/stderr)
@@ -4705,14 +4756,14 @@ backend default {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .command' |
             tee -a /dev/stderr)
     [ "${actual}" == '["/usr/bin/varnish-controller-agent"]' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .args' |
             tee -a /dev/stderr)
@@ -4734,7 +4785,7 @@ backend default {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .volumeMounts[]? | select(.name == "varnish-data")' |
             tee -a /dev/stderr)
@@ -4760,7 +4811,7 @@ backend default {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-agent") |
             .volumeMounts[]? | select(.name == "release-name-data")' |
             tee -a /dev/stderr)
@@ -4782,7 +4833,7 @@ backend default {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? |
             select(.name == "varnish-enterprise-vcli")' | tee -a /dev/stderr |
             yq -r 'length > 0' | tee -a /dev/stderr)
@@ -4802,7 +4853,7 @@ backend default {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? |
             select(.name == "varnish-enterprise-vcli")' | tee -a /dev/stderr)
     [ "${actual}" = "" ]
@@ -4824,17 +4875,17 @@ backend default {
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-vcli")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.env[]? | select(.name == "VARNISH_CONTROLLER_CLI_USERNAME")' |
+        yq -r -o=json -I=0 '.env[]? | select(.name == "VARNISH_CONTROLLER_CLI_USERNAME")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"VARNISH_CONTROLLER_CLI_USERNAME","value":"guest"}' ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.env[]? | select(.name == "VARNISH_CONTROLLER_CLI_PASSWORD")' |
+        yq -r -o=json -I=0 '.env[]? | select(.name == "VARNISH_CONTROLLER_CLI_PASSWORD")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"VARNISH_CONTROLLER_CLI_PASSWORD","value":"passw0rd"}' ]
 }
@@ -4855,12 +4906,12 @@ backend default {
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-vcli")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.env[]? | select(.name == "VARNISH_CONTROLLER_CLI_PASSWORD")' |
+        yq -r -o=json -I=0 '.env[]? | select(.name == "VARNISH_CONTROLLER_CLI_PASSWORD")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"VARNISH_CONTROLLER_CLI_PASSWORD","valueFrom":{"secretKeyRef":{"name":"my-secret","key":"password-key"}}}' ]
 }
@@ -4880,12 +4931,12 @@ backend default {
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-vcli")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.env[]? | select(.name == "VARNISH_CONTROLLER_CLI_INSECURE")' |
+        yq -r -o=json -I=0 '.env[]? | select(.name == "VARNISH_CONTROLLER_CLI_INSECURE")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"VARNISH_CONTROLLER_CLI_INSECURE","value":"true"}' ]
 }
@@ -4904,12 +4955,12 @@ backend default {
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-vcli")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.env[]? | select(.name == "VARNISH_CONTROLLER_CLI_ENDPOINT")' |
+        yq -r -o=json -I=0 '.env[]? | select(.name == "VARNISH_CONTROLLER_CLI_ENDPOINT")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"VARNISH_CONTROLLER_CLI_ENDPOINT","value":"http://varnish-controller-apigw.default.svc.cluster.local:8080"}' ]
 }
@@ -4929,12 +4980,12 @@ backend default {
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-vcli")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.env[]? | select(.name == "VARNISH_CONTROLLER_CLI_ENDPOINT")' |
+        yq -r -o=json -I=0 '.env[]? | select(.name == "VARNISH_CONTROLLER_CLI_ENDPOINT")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"VARNISH_CONTROLLER_CLI_ENDPOINT","value":"http://varnish-controller-apigw.other-namespace.svc.cluster.local:8080"}' ]
 }
@@ -4954,12 +5005,12 @@ backend default {
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-vcli")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.env[]? | select(.name == "VARNISH_CONTROLLER_CLI_ENDPOINT")' |
+        yq -r -o=json -I=0 '.env[]? | select(.name == "VARNISH_CONTROLLER_CLI_ENDPOINT")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"VARNISH_CONTROLLER_CLI_ENDPOINT","value":"http://vc-apigw.default.svc.cluster.local:8080"}' ]
 }
@@ -4979,12 +5030,12 @@ backend default {
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-vcli")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.env[]? | select(.name == "VARNISH_CONTROLLER_CLI_ENDPOINT")' |
+        yq -r -o=json -I=0 '.env[]? | select(.name == "VARNISH_CONTROLLER_CLI_ENDPOINT")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"VARNISH_CONTROLLER_CLI_ENDPOINT","value":"http://varnish-controller-apigw.default.svc.cluster.local:8888"}' ]
 }
@@ -5004,12 +5055,12 @@ backend default {
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-vcli")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.env[]? | select(.name == "VARNISH_CONTROLLER_CLI_ENDPOINT")' |
+        yq -r -o=json -I=0 '.env[]? | select(.name == "VARNISH_CONTROLLER_CLI_ENDPOINT")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"VARNISH_CONTROLLER_CLI_ENDPOINT","value":"http://varnish-controller-apigw.default.svc.cluster.local"}' ]
 }
@@ -5030,12 +5081,12 @@ backend default {
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-vcli")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.env[]? | select(.name == "VARNISH_CONTROLLER_CLI_ENDPOINT")' |
+        yq -r -o=json -I=0 '.env[]? | select(.name == "VARNISH_CONTROLLER_CLI_ENDPOINT")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"VARNISH_CONTROLLER_CLI_ENDPOINT","value":"https://varnish-controller-apigw.default.svc.cluster.local"}' ]
 }
@@ -5056,12 +5107,12 @@ backend default {
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-vcli")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.env[]? | select(.name == "VARNISH_CONTROLLER_CLI_ENDPOINT")' |
+        yq -r -o=json -I=0 '.env[]? | select(.name == "VARNISH_CONTROLLER_CLI_ENDPOINT")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"VARNISH_CONTROLLER_CLI_ENDPOINT","value":"https://varnish-controller-apigw.default.svc.cluster.local:4444"}' ]
 }
@@ -5082,12 +5133,12 @@ backend default {
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-vcli")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.env[]? | select(.name == "VARNISH_CONTROLLER_CLI_ENDPOINT")' |
+        yq -r -o=json -I=0 '.env[]? | select(.name == "VARNISH_CONTROLLER_CLI_ENDPOINT")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"VARNISH_CONTROLLER_CLI_ENDPOINT","value":"https://varnish-controller.example.com"}' ]
 }
@@ -5106,13 +5157,13 @@ backend default {
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-vcli")' |
             tee -a /dev/stderr)
 
     # Note: the script is actually tested in E2E
     local actual=$(echo "$container" |
-        yq -r -c '.lifecycle.preStop.exec.command | first' |
+        yq -r -o=json -I=0 '.lifecycle.preStop.exec.command[0]' |
             tee -a /dev/stderr)
     [ "${actual}" == '/bin/sh' ]
 }
@@ -5133,14 +5184,14 @@ backend default {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-vcli") |
             .env[]? | select(.name == "FOO")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"FOO","value":"bar"}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-vcli") |
             .env[]? | select(.name == "BAZ")' |
             tee -a /dev/stderr)
@@ -5168,14 +5219,14 @@ backend default {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-vcli") |
             .env[]? | select(.name == "RELEASE_NAME")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"RELEASE_NAME","value":"release-name"}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-vcli") |
             .env[]? | select(.name == "RELEASE_NAMESPACE")' |
             tee -a /dev/stderr)
@@ -5200,14 +5251,14 @@ backend default {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-vcli") |
             .env[]? | select(.name == "FOO")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"FOO","value":"bar"}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-vcli") |
             .env[]? | select(.name == "BAZ")' |
             tee -a /dev/stderr)
@@ -5234,14 +5285,14 @@ backend default {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-vcli") |
             .env[]? | select(.name == "FROM_CONFIGMAP")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"FROM_CONFIGMAP","valueFrom":{"configMapKeyRef":{"key":"my-key","name":"my-configmap"}}}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-vcli") |
             .env[]? | select(.name == "FROM_SECRET")' |
             tee -a /dev/stderr)
@@ -5263,7 +5314,7 @@ backend default {
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-vcli") |
             .resources' | tee -a /dev/stderr)
 
@@ -5281,7 +5332,7 @@ backend default {
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-vcli") |
             .resources' | tee -a /dev/stderr)
 
@@ -5304,7 +5355,7 @@ backend default {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-vcli") |
             .volumeMounts[]? | select(.name == "varnish-data")' |
             tee -a /dev/stderr)
@@ -5331,7 +5382,7 @@ backend default {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-vcli") |
             .volumeMounts[]? | select(.name == "release-name-data")' |
             tee -a /dev/stderr)
@@ -5352,7 +5403,7 @@ backend default {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.initContainers[]? | select(.name == "init-agent") |
             length > 0' |
             tee -a /dev/stderr)
@@ -5375,7 +5426,7 @@ backend default {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.initContainers[]? | select(.name == "init-agent") |
             .volumeMounts[]? | select(.name == "varnish-data")' |
             tee -a /dev/stderr)
@@ -5400,7 +5451,7 @@ backend default {
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.initContainers[]? | select(.name == "init-agent") |
             .volumeMounts[]? | select(.name == "release-name-data")' |
             tee -a /dev/stderr)
@@ -5417,7 +5468,7 @@ backend default {
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-ncsa")' |
             tee -a /dev/stderr)
 
@@ -5436,7 +5487,7 @@ backend default {
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-ncsa") |
             .securityContext' | tee -a /dev/stderr)
 
@@ -5464,7 +5515,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-ncsa") |
             .securityContext' | tee -a /dev/stderr)
 
@@ -5489,7 +5540,7 @@ release-namespace: {{ .Release.Namespace }}
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-ncsa") |
             .securityContext' | tee -a /dev/stderr)
 
@@ -5516,7 +5567,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-ncsa") |
             .securityContext' | tee -a /dev/stderr)
 
@@ -5537,9 +5588,10 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-ncsa") |
-            .args| index(["--help])' |
+            .args' |
+            jq -r -c 'index(["--help"])' |
             tee -a /dev/stderr)
 
     [ "${actual}" != "null" ]
@@ -5557,9 +5609,10 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-ncsa") |
-            .args| index(["--help])' |
+            .args' |
+            jq -r -c 'index(["--help"])' |
             tee -a /dev/stderr)
 
     [ "${actual}" != 'null' ]
@@ -5578,7 +5631,7 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-ncsa") |
             .image' |
             tee -a /dev/stderr)
@@ -5601,7 +5654,7 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-ncsa") |
             .image' |
             tee -a /dev/stderr)
@@ -5617,7 +5670,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-ncsa") |
             .startupProbe' | tee -a /dev/stderr)
 
@@ -5637,7 +5690,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-ncsa") |
             .startupProbe' | tee -a /dev/stderr)
 
@@ -5657,7 +5710,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-ncsa") |
             .readinessProbe' | tee -a /dev/stderr)
 
@@ -5673,7 +5726,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-ncsa") |
             .readinessProbe' | tee -a /dev/stderr)
 
@@ -5693,7 +5746,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-ncsa") |
             .livenessProbe' | tee -a /dev/stderr)
 
@@ -5709,7 +5762,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-ncsa") |
             .livenessProbe' | tee -a /dev/stderr)
 
@@ -5728,7 +5781,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-ncsa") |
             .resources' | tee -a /dev/stderr)
 
@@ -5743,7 +5796,7 @@ release-namespace: to-be-override
         --namespace default \
         --show-only ${template} \
         . || echo "---") | tee -a /dev/stderr |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-ncsa") |
             .resources' | tee -a /dev/stderr)
 
@@ -5763,7 +5816,7 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-ncsa") |
             .volumeMounts[]? | select(.name == "varnish-data")' |
             tee -a /dev/stderr)
@@ -5787,7 +5840,7 @@ release-namespace: to-be-override
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-ncsa") |
             .volumeMounts[]? | select(.name == "release-name-data")' |
             tee -a /dev/stderr)
@@ -5835,12 +5888,12 @@ EOF
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrole"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrole"' |
             tee -a /dev/stderr)
     [ "${actual}" = 'null' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrolebinding"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrolebinding"' |
             tee -a /dev/stderr)
     [ "${actual}" = 'null' ]
 }
@@ -5887,12 +5940,12 @@ EOF
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrole"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrole"' |
             tee -a /dev/stderr)
     [ "${actual}" = 'b341e3a03d6bb568e16c2ccbfdc281924ad1a771b73fd2c4198a54a6ce568ebe' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrolebinding"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrolebinding"' |
             tee -a /dev/stderr)
     [ "${actual}" = 'ba049cef23c6407b1c3866a543d8b6cb6b52e01cc40b18774021761b3560424e' ]
 }
@@ -5937,12 +5990,12 @@ EOF
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrole"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrole"' |
             tee -a /dev/stderr)
     [ "${actual}" = 'null' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrolebinding"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrolebinding"' |
             tee -a /dev/stderr)
     [ "${actual}" = 'null' ]
 }
@@ -5989,12 +6042,12 @@ EOF
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrole"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrole"' |
             tee -a /dev/stderr)
     [ "${actual}" = 'dd5731f8b37e11291ee9d37e4efdae991f3b58c4f863d75b3faac538a4df6ab3' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrolebinding"' |
+        yq -r -o=json -I=0 '.spec.template.metadata.annotations."checksum/release-name-extra-clusterrolebinding"' |
             tee -a /dev/stderr)
     [ "${actual}" = '52e43eed97374991f0ca4fd84283acbbf54134898bb5b36c4dc70a03ce595805' ]
 }
@@ -6011,7 +6064,7 @@ EOF
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '.spec.template.spec.volumes[]? | select(.name == "varnish-license-volume")' |
+        yq -r -o=json -I=0 '.spec.template.spec.volumes[]? | select(.name == "varnish-license-volume")' |
         tee -a /dev/stderr)
 
     [ "${actual}" == '{"name":"varnish-license-volume","secret":{"secretName":"test-value"}}' ]
@@ -6066,14 +6119,14 @@ EOF
         tee -a /dev/stderr)
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-ncsa") |
             .env[]? | select(.name == "FOO")' |
             tee -a /dev/stderr)
     [ "${actual}" == '{"name":"FOO","value":"bar"}' ]
 
     local actual=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise-ncsa") |
             .env[]? | select(.name == "BAZ")' |
             tee -a /dev/stderr)

--- a/varnish-enterprise/test/unit_common/common.bats
+++ b/varnish-enterprise/test/unit_common/common.bats
@@ -2959,7 +2959,7 @@ env: {
         . || echo "---") 2>&1 |
         tee -a /dev/stderr)
 
-    [[ "${actual}" == *"Either MSE or MSE4 must be enabled: 'server.mse.enabled' or 'server.mse4.enabled'"* ]]
+    [[ "${actual}" == *"Exactly one of MSE, MSE4 or malloc must be enabled:"* ]]
 }
 
 @test "${kind}/mse/config: can be disabled when mse4 is enabled" {
@@ -3017,7 +3017,7 @@ env: {
         . || echo "---") 2>&1 |
         tee -a /dev/stderr)
 
-    [[ "${actual}" == *"Only one of MSE or MSE4 can be enabled at the same time: 'server.mse.enabled' or 'server.mse4.enabled'"* ]]
+    [[ "${actual}" == *"Only one of these storages can be enabled at the same time:"* ]]
 }
 
 @test "${kind}/mse4/memoryTarget: can be configured" {
@@ -3165,6 +3165,59 @@ env: {
             tee -a /dev/stderr)
     [ "${actual}" == '' ]
 }
+
+@test "${kind}/malloc/config: not configured by default" {
+    cd "$(chart_dir)"
+
+    local object=$((helm template \
+        --set "server.kind=${kind}" \
+        --set 'server.malloc.enabled=true' \
+        --namespace default \
+        --show-only ${template} \
+        . || echo "---") |
+        tee -a /dev/stderr)
+
+    local container=$(echo "$object" |
+        yq -r -c '
+            .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
+            tee -a /dev/stderr)
+
+    local actual=$(echo "$container" |
+        yq -r -c '.command | .[ index("-s") + 1 ] | split(",")[1]' |
+            tee -a /dev/stderr)
+    [ "${actual}" == "null" ]
+}
+
+@test "${kind}/malloc/config: can be configured" {
+    cd "$(chart_dir)"
+
+    local object=$((helm template \
+        --set "server.kind=${kind}" \
+        --set 'server.malloc.enabled=true' \
+        --set 'server.malloc.size=2G' \
+        --set 'server.malloc.transient.size=1G' \
+        --namespace default \
+        --show-only ${template} \
+        . || echo "---") |
+        tee -a /dev/stderr)
+
+    local container=$(echo "$object" |
+        yq -r -c '
+            .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
+            tee -a /dev/stderr)
+
+    local actual=$(echo "$container" |
+        yq -r -c '.command | .[ indices("-s")[0]+1 ] | split(",")[1]' |
+            tee -a /dev/stderr)
+    [ "${actual}" == "2G" ]
+
+    local actual=$(echo "$container" |
+        yq -r -c '.command |  .[ indices("-s")[1]+1]' |
+            tee -a /dev/stderr)
+    [ "${actual}" == "Transient=malloc,1G" ]
+
+}
+
 
 @test "${kind}/delayedHaltSeconds: not enabled by default" {
     cd "$(chart_dir)"

--- a/varnish-enterprise/test/unit_common/common.bats
+++ b/varnish-enterprise/test/unit_common/common.bats
@@ -3178,12 +3178,13 @@ env: {
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[ index("-s") + 1 ] | split(",")[1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[ index("-s") + 1 ] | split(",")[1]' |
             tee -a /dev/stderr)
     [ "${actual}" == "null" ]
 }
@@ -3202,17 +3203,19 @@ env: {
         tee -a /dev/stderr)
 
     local container=$(echo "$object" |
-        yq -r -c '
+        yq -r -o=json -I=0 '
             .spec.template.spec.containers[]? | select(.name == "varnish-enterprise")' |
             tee -a /dev/stderr)
 
     local actual=$(echo "$container" |
-        yq -r -c '.command | .[ indices("-s")[0]+1 ] | split(",")[1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[ indices("-s")[0]+1 ] | split(",")[1]' |
             tee -a /dev/stderr)
     [ "${actual}" == "2G" ]
 
     local actual=$(echo "$container" |
-        yq -r -c '.command |  .[ indices("-s")[1]+1]' |
+        yq -o=json -I=0 '.command' |
+            jq -r -c '.[ indices("-s")[1]+1 ]' |
             tee -a /dev/stderr)
     [ "${actual}" == "Transient=malloc,1G" ]
 

--- a/varnish-enterprise/values.yaml
+++ b/varnish-enterprise/values.yaml
@@ -23,6 +23,12 @@ global:
   #     - name: registry-quay-k7c2f4m2d5
   imagePullSecrets: []
 
+  # Controls which feature set is active.
+  # "enterprise" enables MSE, MSE4, agent, initAgent, otel, cluster, and NATS features.
+  # "community" restricts to features available in open-source Varnish Cache.
+  # This value is overridden to "community" when publishing the varnish-cache chart.
+  edition: enterprise
+
   # Overrides the default busybox initContainer image.
   initContainer:
     # The image to use for the initContainer.

--- a/varnish-enterprise/values.yaml
+++ b/varnish-enterprise/values.yaml
@@ -438,9 +438,9 @@ server:
   mse:
     # Enables Massive Storage Engine. Only one of `server.mse.enabled` or `server.mse4.enabled` must be enabled.
     #
-    # When set to a string "-", `server.mse.enabled` will be set to an opposite value of `server.mse4.enabled` (i.e. automatically disabling MSE when MSE4 is enabled, and vice versa)
+    # When set to a string "-", or null, `server.mse.enabled` will be set to an opposite value of `server.mse4.enabled` (i.e. automatically disabling MSE when MSE4 is enabled, and vice versa)
     # Availability: v1.6.1
-    # Type: boolean or string
+    # Type: boolean, string or null
     enabled: "-"
 
     # Sets the amount of memory to use for MSE. The value can be set as either a percentage (e.g., "80%"),
@@ -604,6 +604,15 @@ server:
 
       # Sets the storage size for Persistence Volume Claim for MSE4.
       storageSize: "10Gi"
+
+  malloc:
+    # Enables malloc storage, the default storage engine for open-source varnish:
+    enabled: false
+    # Sets the size of the malloc. Default is unbounded.
+    size: ~
+    transient:
+      # Sets the size of the transient buffer. Default is unbounded.
+      size: ~
 
   # Sets the Varnish secret for accessing the varnishd admin interface. Either this value or
   # `server.secretFrom` can be set.


### PR DESCRIPTION
## Main three changes:
1. Adds `global.edition` to the enterprise chart (`enterprise` by default) that gates all enterprise-only features. When set to `community`, implementing enterprise features will fail to compile.

2. Adds `ci/publish-community.sh`, a script that transforms the enterprise chart into a clean community chart at publish time. It switches the edition, points the image at `docker.io/varnish`, sets the correct OSS `appVersion`, and strips enterprise-only value sections entirely so they never appear in the published chart.

3. Updates the README to document the single-source-of-truth approach and the publish script.

The enterprise chart is now the single source of truth for both charts. They can never drift out of sync again.

Usage:
```sh
./ci/publish-community.sh <oss-version> [output-dir]
# e.g.
./ci/publish-community.sh 9.0.3
helm package dist/varnish-cache --destination dist/packages
```

## What to discuss

The old `varnish-cache/` directory is still in the repo. It was hand-maintained separately and is now superseded by this approach. Options:
- Delete it and use only the generated chart going forward
- Keep it temporarily as a reference while we validate the generated chart in CI
- Something else?

## Test plan (what I checked to validate this)

-  `helm lint varnish-enterprise/` passes with default enterprise values
-  `bash ci/publish-community.sh 9.0.3` generates a clean community chart that passes `helm lint`
-  Enterprise chart unit tests: 156 tests passing
-  Common unit tests: 678 tests passing
-  Both `global.edition=community` and `global.edition=enterprise` render the correct resources
-  Attempting to use enterprise features in community mode produces a clear error

Please give this a good review, I don't trust myself and there was indeed some Claude influence, so double don't trust. 