### PR TITLE
orca-chart: Fix references to service.port

### DIFF
--- a/orca-chart/README.md
+++ b/orca-chart/README.md
@@ -19,7 +19,7 @@ The `--set` argument can be used to add configuration values on the command line
 ```sh
 helm install varnish-orca oci://docker.io/varnish/orca-chart \
  --set "orca.varnish.http[0].port=81" \
- --set "service.port=81"
+ --set "service.http.port=81"
 ```
 
 Or simply add `-f values.yaml` to override load the configuration overrides from a `values.yaml` file:
@@ -32,7 +32,8 @@ Here's an example `values.yaml` file:
 
 ```yaml
 service:
-  port: 81
+  http:
+    port: 81
 orca:
   varnish:
     http:

--- a/orca-chart/templates/NOTES.txt
+++ b/orca-chart/templates/NOTES.txt
@@ -13,7 +13,7 @@
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "helm.fullname" . }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "helm.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.service.http.port }}
+  echo http://$SERVICE_IP:{{ .Values.service.http.port | default 80 }}
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "helm.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")

--- a/orca-chart/templates/NOTES.txt
+++ b/orca-chart/templates/NOTES.txt
@@ -13,7 +13,7 @@
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "helm.fullname" . }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "helm.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.service.port }}
+  echo http://$SERVICE_IP:{{ .Values.service.http.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "helm.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")

--- a/orca-chart/templates/tests/test-connection.yaml
+++ b/orca-chart/templates/tests/test-connection.yaml
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "helm.fullname" . }}:{{ .Values.service.port }}']
+      args: ['{{ include "helm.fullname" . }}:{{ .Values.service.http.port }}']
   restartPolicy: Never

--- a/orca-chart/templates/tests/test-connection.yaml
+++ b/orca-chart/templates/tests/test-connection.yaml
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "helm.fullname" . }}:{{ .Values.service.http.port }}']
+      args: ['{{ include "helm.fullname" . }}:{{ .Values.service.http.port | default 80 }}']
   restartPolicy: Never

--- a/orca-chart/test/unit/test_connection.bats
+++ b/orca-chart/test/unit/test_connection.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "Test hook: targets the HTTP service port" {
+    cd "$(chart_dir)"
+    local actual=$((helm template \
+        --namespace default \
+        --show-only templates/tests/test-connection.yaml \
+        .) | yqj '.spec.containers[0].args')
+    [ "${actual}" = '["release-name-orca-chart:80"]' ]
+}
+
+@test "Test hook: follows a configured HTTP service port" {
+    cd "$(chart_dir)"
+    local actual=$((helm template \
+        --set 'service.http.port=8080' \
+        --namespace default \
+        --show-only templates/tests/test-connection.yaml \
+        .) | yqj '.spec.containers[0].args')
+    [ "${actual}" = '["release-name-orca-chart:8080"]' ]
+}

--- a/orca-chart/test/unit/test_connection.bats
+++ b/orca-chart/test/unit/test_connection.bats
@@ -20,3 +20,15 @@ load _helpers
         .) | yqj '.spec.containers[0].args')
     [ "${actual}" = '["release-name-orca-chart:8080"]' ]
 }
+
+# Matches the `default 80` the Services apply, so an override that drops the
+# port cannot render a bare trailing colon here while the Service says 80.
+@test "Test hook: falls back to 80 when the port is unset" {
+    cd "$(chart_dir)"
+    local actual=$((helm template \
+        --set 'service.http.port=null' \
+        --namespace default \
+        --show-only templates/tests/test-connection.yaml \
+        .) | yqj '.spec.containers[0].args')
+    [ "${actual}" = '["release-name-orca-chart:80"]' ]
+}


### PR DESCRIPTION
The chart has no service.port value, the HTTP port lives at service.http.port. Three places referenced the missing key, so each rendered an empty string.

CI never caught it because it only runs helm template, never helm test, and nothing in the unit suite rendered that template. Add coverage for the test hook's args along with the fix.