### PR TITLE
Fix version_bumper.yaml not checking for empty appVersion

### DIFF
--- a/.github/workflows/version_bumper.yaml
+++ b/.github/workflows/version_bumper.yaml
@@ -58,6 +58,13 @@ jobs:
 
           # Clean up any leading/trailing whitespace from the version strings
           CURRENT_APP_VERSION=$(echo "$CURRENT_APP_VERSION" | xargs)
+          LATEST_APP_VERSION=$(echo "$LATEST_APP_VERSION" | xargs)
+
+          if [ -z "$LATEST_APP_VERSION" ]; then
+            echo "::warning file=$CHART_PATH::Could not determine latest app version for $CHART_NAME (docker run or version extraction may have failed). Skipping."
+            echo "version_match=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           echo "Processing Chart: $CHART_NAME (${{ matrix.chart_details.chart_dir }})"
           echo "Current appVersion: $CURRENT_APP_VERSION"


### PR DESCRIPTION
This came up in #122, where the chart version got bumped but appVersion ended up as an empty string.

The version_bumper workflow never checked whether LATEST_APP_VERSION actually came back non-empty from the docker run step. If that step fails for any reason, the empty string still gets treated as a "new" version since it doesn't match the current one, and a PR goes out with a blank appVersion.

This adds a check that skips the run instead of opening a bad PR when the version can't be determined.